### PR TITLE
ProActiveRuntime#getActiveObjects returned wrong list of active objects

### DIFF
--- a/programming-core/src/main/java/org/objectweb/proactive/core/runtime/ProActiveRuntimeImpl.java
+++ b/programming-core/src/main/java/org/objectweb/proactive/core/runtime/ProActiveRuntimeImpl.java
@@ -769,26 +769,20 @@ public class ProActiveRuntimeImpl extends RuntimeRegistrationEventProducerImpl i
         }
 
         synchronized (bodyList) {
-            for (int i = 0; i < bodyList.size(); i++) {
-                UniqueID bodyID = bodyList.get(i);
-
+            for (Iterator<UniqueID> iterator = bodyList.iterator(); iterator.hasNext();) {
+                UniqueID bodyID = iterator.next();
                 // check if the body is still on this vm
                 Body body = localBodystore.getLocalBody(bodyID);
 
                 if (body == null) {
-                    // runtimeLogger.warn("body null");
                     // the body with the given ID is not any more on this
                     // ProActiveRuntime
                     // unregister it from this ProActiveRuntime
-                    unregisterBody(nodeName, bodyID);
+                    iterator.remove();
                 } else {
-                    // the body is on this runtime then return adapter and class
-                    // name of the reified
-                    // object to enable the construction of stub-proxy couple.
-                    localBodies.add(0, body.getRemoteAdapter());
+                    localBodies.add(body.getRemoteAdapter());
                 }
             }
-
             return localBodies;
         }
     }
@@ -847,18 +841,17 @@ public class ProActiveRuntimeImpl extends RuntimeRegistrationEventProducerImpl i
         }
 
         synchronized (bodyList) {
-            for (int i = 0; i < bodyList.size(); i++) {
-                UniqueID bodyID = bodyList.get(i);
+            for (Iterator<UniqueID> iterator = bodyList.iterator(); iterator.hasNext();) {
+                UniqueID bodyID = iterator.next();
 
                 // check if the body is still on this vm
                 Body body = localBodystore.getLocalBody(bodyID);
 
                 if (body == null) {
-                    // runtimeLogger.warn("body null");
                     // the body with the given ID is not any more on this
                     // ProActiveRuntime
                     // unregister it from this ProActiveRuntime
-                    unregisterBody(nodeName, bodyID);
+                    iterator.remove();
                 } else {
                     String objectClass = body.getReifiedObject().getClass().getName();
 
@@ -929,29 +922,6 @@ public class ProActiveRuntimeImpl extends RuntimeRegistrationEventProducerImpl i
                 // bodyID.toString());
                 bodyList.add(bodyID);
             }
-        }
-    }
-
-    /**
-     * Unregisters the specified <code>UniqueID</code> from the node
-     * corresponding to the nodeName key
-     * 
-     * @param nodeName
-     *            The key where to remove the <code>UniqueID</code>
-     * @param bodyID
-     *            The <code>UniqueID</code> to remove
-     */
-    private void unregisterBody(String nodeName, UniqueID bodyID) {
-        // System.out.println("in remove id= "+ bodyID.toString());
-        // System.out.println("array size
-        // "+((ArrayList)hostsMap.get(nodeName)).size());
-        List<UniqueID> bodyList = this.nodeMap.get(nodeName).getActiveObjectsId();
-
-        synchronized (bodyList) {
-            bodyList.remove(bodyID);
-
-            // System.out.println("array size
-            // "+((ArrayList)hostsMap.get(nodeName)).size());
         }
     }
 

--- a/programming-core/src/test/java/org/objectweb/proactive/core/node/NodeImplTest.java
+++ b/programming-core/src/test/java/org/objectweb/proactive/core/node/NodeImplTest.java
@@ -1,0 +1,39 @@
+package org.objectweb.proactive.core.node;
+
+import org.objectweb.proactive.api.PAActiveObject;
+import org.objectweb.proactive.core.config.CentralPAPropertyRepository;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+
+public class NodeImplTest {
+
+    @Before
+    public void disableRMISecurityManager() throws Exception {
+        CentralPAPropertyRepository.PA_CLASSLOADING_USEHTTP.setValue(false);
+    }
+
+    // The bug actually lies in ProActiveRuntimeImpl but is visible when trying to kill AOs on a node
+    @Test
+    public void allActiveObjectsAreKilled() throws Exception {
+        Node localNode = NodeFactory.createLocalNode("testing", false, "testing");
+
+        PAActiveObject.newActive(SimpleActiveObject.class.getName(), null, localNode);
+        PAActiveObject.newActive(SimpleActiveObject.class.getName(), null, localNode);
+        localNode.killAllActiveObjects();
+
+        assertEquals(0, localNode.getNumberOfActiveObjects());
+
+        // second kill reveals the issue
+        PAActiveObject.newActive(SimpleActiveObject.class.getName(), null, localNode);
+        PAActiveObject.newActive(SimpleActiveObject.class.getName(), null, localNode);
+        localNode.killAllActiveObjects();
+
+        assertEquals(0, localNode.getNumberOfActiveObjects());
+    }
+
+    public static class SimpleActiveObject {
+    }
+}


### PR DESCRIPTION
Because the list of bodies was traversed while deleting elements, an incompete
list of active objects could be returned.

For instance if a body at pos=3 was removed, then the list is shifted, and
for the next iteration, element that was at pos=4 could be missed.

This was preventing node cleaning to be performed, thus breaking node cleaning
in the Scheduler as well as observed with tests such as TestJobRemoved.
