### PR TITLE
Reduce logs verbosity in case of network disruption

### DIFF
--- a/programming-core/src/main/java/org/objectweb/proactive/core/remoteobject/RemoteObjectAdapter.java
+++ b/programming-core/src/main/java/org/objectweb/proactive/core/remoteobject/RemoteObjectAdapter.java
@@ -156,10 +156,11 @@ public class RemoteObjectAdapter implements RemoteObject, Serializable {
             // Log for keeping a trace
             String methodName = message.getMethodName();
             if (!methodName.equals("killRT")) {
-                LOGGER_RO.warn(displayCaller + " : unable to contact remote object " + displayROURI +
-                    " when calling method " + message.getMethodName(), e);
+                LOGGER_RO.warn(displayCaller + ": unable to contact remote object " + displayROURI +
+                    " when calling method " + message.getMethodName());
+                LOGGER_RO.debug(e.getMessage(), e);
             } else if (LOGGER_RO.isDebugEnabled()) {
-                LOGGER_RO.debug(displayCaller + " : unable to contact remote object " + displayROURI +
+                LOGGER_RO.debug(displayCaller + ": unable to contact remote object " + displayROURI +
                     " when calling method " + message.getMethodName(), e);
             }
             return new SynchronousReplyImpl(new MethodCallResult(null, e));


### PR DESCRIPTION
Stack trace is no longer print at WARN level but only at DEBUG level.

This patch resolves ow2-proactive/scheduling#2366.
