### PR TITLE
Bump Jetty and Guava dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -145,9 +145,9 @@ project(':programming-core') {
 
     dependencies {
         compile(
-                'org.eclipse.jetty:jetty-server:9.2.13.v20150730',
-                'org.eclipse.jetty:jetty-servlet:9.2.13.v20150730',
-                'org.eclipse.jetty:jetty-xml:9.2.13.v20150730',
+                'org.eclipse.jetty:jetty-server:9.2.14.v20151106',
+                'org.eclipse.jetty:jetty-servlet:9.2.14.v20151106',
+                'org.eclipse.jetty:jetty-xml:9.2.14.v20151106',
 
                 'org.tmatesoft.svnkit:trilead-ssh2:build213-svnkit-1.3-patch',
 

--- a/build.gradle
+++ b/build.gradle
@@ -254,7 +254,7 @@ project('programming-extensions:programming-extension-dataspaces') {
                 vfs2CompileDependencies,
                 project(':programming-extensions:programming-extension-vfsprovider'),
                 project(':programming-util'),
-                'com.google.guava:guava:18.0'
+                'com.google.guava:guava:19.0'
         )
         testCompile(
                 project(':programming-extensions:programming-extension-vfsprovider').sourceSets.test.output,


### PR DESCRIPTION
Jetty update is mainly to fix a memory leak with QueuedThreadPool.

See release notes:

https://github.com/eclipse/jetty.project/blob/master/VERSION.txt

Guava update is to be in line with version used in scheduling project.
