### PR TITLE
work on #1310 : Improve ProActiveInet address detection mechanism

### DIFF
--- a/programming-core/src/main/java/org/objectweb/proactive/core/config/CentralPAPropertyRepository.java
+++ b/programming-core/src/main/java/org/objectweb/proactive/core/config/CentralPAPropertyRepository.java
@@ -36,15 +36,15 @@
  */
 package org.objectweb.proactive.core.config;
 
-import java.net.Socket;
-
 import org.objectweb.proactive.core.config.PAProperties.PAPropertiesLoaderSPI;
 import org.objectweb.proactive.utils.OperatingSystem;
+
+import java.net.Socket;
 
 
 /**
  * The central repository of PAProperty
- *
+ * <p/>
  * Ideally the PAProperty should be defined in their own module then registered into
  * the {@link PAProperties} singleton. Unfortunately, until ProActive 4.3.0 it was only
  * possible to declare a ProActive property in a centralized enumeration. This
@@ -58,28 +58,16 @@ public class CentralPAPropertyRepository implements PAPropertiesLoaderSPI {
     static public PAPropertyString JAVA_SECURITY_POLICY = new PAPropertyString("java.security.policy", true);
 
     /**
-     * If IPv6 is available on the operating system the default preference is to prefer an IPv4-mapped address over an IPv6 address
-     */
-    static public PAPropertyBoolean PREFER_IPV6_ADDRESSES = new PAPropertyBoolean(
-        "java.net.preferIPv6Addresses", true);
-
-    /**
-     * If IPv6 is available on the operating system the underlying native socket will be an IPv6 socket. This allows Java(tm) applications to connect too, and accept connections from, both IPv4 and IPv6 hosts.
-     */
-    static public PAPropertyBoolean PREFER_IPV4_STACK = new PAPropertyBoolean("java.net.preferIPv4Stack",
-        true);
-
-    /**
      * Indicate the Fractal provider class, to the ProActive implementation of
      * Fractal/GCM set it to org.objectweb.proactive.core.component.Fractive
      */
     static public PAPropertyString FRACTAL_PROVIDER = new PAPropertyString("fractal.provider", true);
 
     static public PAPropertyString JAVA_SECURITY_AUTH_LOGIN_CONFIG = new PAPropertyString(
-        "java.security.auth.login.config", true);
+            "java.security.auth.login.config", true);
 
     static public PAPropertyString JAVAX_XML_TRANSFORM_TRANSFORMERFACTORY = new PAPropertyString(
-        "javax.xml.transform.TransformerFactory", true);
+            "javax.xml.transform.TransformerFactory", true);
 
     /* ------------------------------------
      *  PROACTIVE
@@ -87,25 +75,25 @@ public class CentralPAPropertyRepository implements PAPropertiesLoaderSPI {
 
     /**
      * ProActive Configuration file location
-     *
+     * <p/>
      * If set ProActive will load the configuration file at the given location.
      */
     static public PAPropertyString PA_CONFIGURATION_FILE = new PAPropertyString("proactive.configuration",
-        false);
+            false);
 
     /**
      * Indicates where ProActive is installed
-     *
+     * <p/>
      * Can be useful to write generic deployment descriptor by using a JavaPropertyVariable
      * to avoid hard coded path.
-     *
+     * <p/>
      * Used in unit and functional tests
      */
     static public PAPropertyString PA_HOME = new PAPropertyString("proactive.home", false);
 
     /**
      * Indicates what is the operating system of the local machine
-     *
+     * <p/>
      * It is not redundant with "os.name" since the only valid values those from <code>OperatingSystem</code>.
      * Often users are only interested to know if the computer is running unix or windows.
      *
@@ -115,7 +103,7 @@ public class CentralPAPropertyRepository implements PAPropertiesLoaderSPI {
 
     /**
      * Log4j configuration file location
-     *
+     * <p/>
      * If set the specified log4j configuration file is used. Otherwise the default one,
      * Embedded in the ProActive jar is used.
      */
@@ -123,24 +111,23 @@ public class CentralPAPropertyRepository implements PAPropertiesLoaderSPI {
 
     /**
      * URI of the remote log collector
-     *
      */
     static public PAPropertyString PA_LOG4J_COLLECTOR = new PAPropertyString("proactive.log4j.collector",
-        false);
+            false);
 
     /**
      * Qualified name of the flushing provider to use
      */
     static public PAPropertyString PA_LOG4J_APPENDER_PROVIDER = new PAPropertyString(
-        "proactive.log4j.appender.provider", false,
-        "org.objectweb.proactive.core.util.log.remote.ThrottlingProvider");
+            "proactive.log4j.appender.provider", false,
+            "org.objectweb.proactive.core.util.log.remote.ThrottlingProvider");
 
     /**
      * Specifies the name of the ProActive Runtime
-     *
+     * <p/>
      * By default a random name is assigned to a ProActive Runtime. This property allows
      * to choose the name of the Runtime to be able to perform lookups.
-     *
+     * <p/>
      * By default, the name of a runtime starts with PA_JVM</strong>
      */
     static public PAPropertyString PA_RUNTIME_NAME = new PAPropertyString("proactive.runtime.name", false);
@@ -149,15 +136,15 @@ public class CentralPAPropertyRepository implements PAPropertiesLoaderSPI {
      * this property should be used when one wants to start only a runtime without an additional main class
      */
     static public PAPropertyBoolean PA_RUNTIME_STAYALIVE = new PAPropertyBoolean(
-        "proactive.runtime.stayalive", false, true);
+            "proactive.runtime.stayalive", false, true);
 
     /**
      * Terminates the Runtime when the Runtime becomes empty
-     *
+     * <p/>
      * If true, when all bodies have been terminated the ProActive Runtime will exit
      */
     static public PAPropertyBoolean PA_EXIT_ON_EMPTY = new PAPropertyBoolean("proactive.exit_on_empty",
-        false, false);
+            false, false);
 
     /**
      * Boolean to activate automatic continuations for this runtime.
@@ -166,19 +153,19 @@ public class CentralPAPropertyRepository implements PAPropertiesLoaderSPI {
 
     /**
      * Timeout value for future in synchronous requests.
-     * can be used to set timeout on synchronous calls. Impossible otherwise 
+     * can be used to set timeout on synchronous calls. Impossible otherwise
      * default value 0, no timeout
      */
     static public PAPropertyLong PA_FUTURE_SYNCHREQUEST_TIMEOUT = new PAPropertyLong(
-        "proactive.future.synchrequest.timeout", false, 0);
+            "proactive.future.synchrequest.timeout", false, 0);
 
     /**
      * Period of the future monitoring ping, in milliseconds
-     *
+     * <p/>
      * If set to 0, then future monitoring is disabled
      */
     static public PAPropertyInteger PA_FUTUREMONITORING_TTM = new PAPropertyInteger(
-        "proactive.futuremonitoring.ttm", false);
+            "proactive.futuremonitoring.ttm", false);
 
     /**
      * When this property is set to true, at each proactive call, the stack trace context of the call is embedded in the future.
@@ -188,11 +175,11 @@ public class CentralPAPropertyRepository implements PAPropertiesLoaderSPI {
      * in the stack will be kept and forwarded
      */
     static public PAPropertyBoolean PA_STACKTRACE = new PAPropertyBoolean("proactive.stack_trace", false,
-        false);
+            false);
 
     /**
      * Activates the legacy SAX ProActive Descriptor parser
-     *
+     * <p/>
      * To check if the new JAXP parser introduced regressions.
      */
     static public PAPropertyBoolean PA_LEGACY_PARSER = new PAPropertyBoolean("proactive.legacy.parser", false);
@@ -203,78 +190,150 @@ public class CentralPAPropertyRepository implements PAPropertiesLoaderSPI {
 
     /**
      * ProActive Communication protocol
-     *
+     * <p/>
      * Suppported values are: rmi, rmissh, http
      */
     static public PAPropertyString PA_COMMUNICATION_PROTOCOL = new PAPropertyString(
-        "proactive.communication.protocol", false, "rmi");
+            "proactive.communication.protocol", false, "rmi");
 
     /**
      * ProActive Runtime Hostname (or IP Address)
-     *
+     * <p/>
      * This option can be used to set manually the Runtime IP Address. Can be
      * useful when the Java networking stack return a bad IP address (example: multihomed machines).
-     *
      */
     static public PAPropertyString PA_HOSTNAME = new PAPropertyString("proactive.hostname", false);
 
     /**
      * Toggle DNS resolution
-     *
+     * <p/>
      * When true IP addresses are used instead of FQDNs. Can be useful with misconfigured DNS servers
      * or strange /etc/resolv.conf files. FQDNs passed by user or 3rd party tools are resolved and converted
      * into IP addresses
-     *
      */
     static public PAPropertyBoolean PA_NET_USE_IP_ADDRESS = new PAPropertyBoolean("proactive.useIPaddress",
-        false);
+            false);
 
-    /** Enable or disable IPv6
-     *
+    /**
+     * Enable or disable IPv6. When IPv6 is disabled, all IPv6 addresses will be ignored.
      */
     static public PAPropertyBoolean PA_NET_DISABLE_IPv6 = new PAPropertyBoolean("proactive.net.disableIPv6",
-        false, true);
+            false, false);
+
+    /**
+     * IPv6 stack is preferred by default, since on a dual-stack machine IPv6 socket can talk to both IPv4 and IPv6 peers.
+     * <p/>
+     * This setting can be changed through the java.net.preferIPv4Stack=<true|false> system property.
+     */
+    static public PAPropertyBoolean PREFER_IPV4_STACK = new PAPropertyBoolean("java.net.preferIPv4Stack",
+            true);
+
+    /**
+     * By default, we would prefer IPv4 addresses over IPv6 addresses, i.e., when querying the name service (e.g., DNS service),
+     * we would return Ipv4 addresses ahead of IPv6 addresses. There are two reasons for this choice:
+     * <p/>
+     * - There are some applications that expect an IPv4 address textual format, i.e. "%d.%d.%d.%d". Using an IPv4 address minimizes the surprises;
+     * - Using IPv4 address, we can use one call (with an IPv6 socket) to reach either a legacy IPv4-only service, or an IPv6 service (unless the IPv6 service is on a Ipv6 only node).
+     * This setting can be changed through the system property java.net.preferIPv6Addresses=true|false
+     */
+    static public PAPropertyBoolean PREFER_IPV6_ADDRESSES = new PAPropertyBoolean(
+            "java.net.preferIPv6Addresses", true, false);
+
 
     /**
      * Toggle loopback IP address usage
-     *
-     * When true loopback IP address usage is avoided. Since Remote adapters contain only one
-     * endpoint the right IP address must be used. This property must be set to true if a loopback
-     * address is returned by the Java INET stack.
-     *
+     * <p/>
+     * When true (default) loopback IP address usage is avoided. Usage of the loopback address could be allowed when
+     * deploying a service which communicates only locally, otherwise it must remain disabled.
+     * <p/>
      * If only a loopback address exists, it is used.
      */
     static public PAPropertyBoolean PA_NET_NOLOOPBACK = new PAPropertyBoolean("proactive.net.nolocal", false,
-        true);
+            false);
 
     /**
      * Toggle Private IP address usage
-     *
-     * When true private IP address usage is avoided. Since Remote adapters contain only one
-     * endpoint the right IP address must be used. This property must be set to true if a private
-     * address is returned by the Java INET stack and this private IP is not reachable by other hosts.
+     * <p/>
+     * When true private IP address usage is avoided. Private addresses are :
+     * <p/>
+     * 10.0.0.0/8
+     * 172.16.0.0/12
+     * 192.168.0.0/16
+     * <p/>
+     * Warning: Often a network will only contain private addresses, in that case setting this property to true
+     * will result in finding no suitable interface for ProActive.
+     * <p/>
+     * Refer to:
+     * https://en.wikipedia.org/wiki/Private_network
      */
-    static public PAPropertyBoolean PA_NET_NOPRIVATE = new PAPropertyBoolean("proactive.net.noprivate", false);
+    static public PAPropertyBoolean PA_NET_NOPRIVATE = new PAPropertyBoolean("proactive.net.noprivate", false,
+            false);
+
+    /**
+     * Toggle Link Local IP address usage
+     * <p/>
+     * When true, link local IP address usage is avoided. Link local addresses are not routed and thus should be discarded.
+     * In addition, an extra IPv6 link-local address is now assigned to each network interface,
+     * (in addition to the standard interface address), and this prevents the correct IP address to be chosen.
+     * https://en.wikipedia.org/wiki/Link-local_address
+     */
+    static public PAPropertyBoolean PA_NET_NOLINKLOCAL = new PAPropertyBoolean("proactive.net.nolinklocal",
+            false, true);
 
     /**
      * Select the network interface
      */
     static public PAPropertyString PA_NET_INTERFACE = new PAPropertyString("proactive.net.interface", false);
 
-    /** Select the netmask to use (xxx.xxx.xxx.xxx/xx)
-     *
+    /**
+     * Select the netmask to use (xxx.xxx.xxx.xxx/xx)
+     * <p/>
      * Does not work with IPv6 addresses
      */
     static public PAPropertyString PA_NET_NETMASK = new PAPropertyString("proactive.net.netmask", false);
 
     /**
+     * Select the network interface which has the fastest Internet connection.
+     * <p/>
+     * When several interfaces are installed, usually only one has access to the Internet, which means that this algorithm
+     * can be used to automatically select the most "visible" interface among those available.
+     * <p/>
+     * This property can be enabled if you are connected to the Internet, otherwise it should be set to false,
+     * or the proactive.net.fastest.connection.server property must be used to check connection with a well-known server.
+     */
+    static public PAPropertyBoolean PA_NET_FASTEST_CONNECTION = new PAPropertyBoolean(
+            "proactive.net.fastest.connection", false, false);
+
+    /**
+     * Timeout used for the internet connection detection
+     */
+    static public PAPropertyInteger PA_NET_FASTEST_CONNECTION_TIMEOUT = new PAPropertyInteger(
+            "proactive.net.fastest.connection.timeout", false, 1000);
+
+    /**
+     * Server to connect to during the internet connection check.
+     * <p/>
+     * If you are behind a proxy, you can replace this server/port by the proxy hostname to detect the most "visible" interface.
+     */
+    static public PAPropertyString PA_NET_FASTEST_CONNECTION_SERVER = new PAPropertyString(
+            "proactive.net.fastest.connection.server", false, "google.com");
+
+    /**
+     * Port to connect to during the internet connection check.
+     * <p/>
+     * If you are behind a proxy, you can replace this server/port by the proxy hostname to detect the most "visible" interface.
+     */
+    static public PAPropertyInteger PA_NET_FASTEST_CONNECTION_PORT = new PAPropertyInteger(
+            "proactive.net.fastest.connection.port", false, 80);
+
+    /**
      * RMI/SSH black voodoo
-     *
+     * <p/>
      * Can be used to fix broken networks (multihomed, broken DNS etc.). You probably want
      * to post on the public ProActive mailing list before using this property.
      */
     static public PAPropertyString PA_NET_SECONDARYNAMES = new PAPropertyString(
-        "proactive.net.secondaryNames", false);
+            "proactive.net.secondaryNames", false);
 
     static public PAPropertyBoolean SCHEMA_VALIDATION = new PAPropertyBoolean("schema.validation", true, true);
 
@@ -284,16 +343,16 @@ public class CentralPAPropertyRepository implements PAPropertiesLoaderSPI {
 
     /**
      * Assigns a TCP port to RMI
-     *
+     * <p/>
      * this property identifies the default port used by the RMI communication protocol
      */
     static public PAPropertyInteger PA_RMI_PORT = new PAPropertyInteger("proactive.rmi.port", false, 1099);
 
     static public PAPropertyString JAVA_RMI_SERVER_CODEBASE = new PAPropertyString(
-        "java.rmi.server.codebase", true);
+            "java.rmi.server.codebase", true);
 
     static public PAPropertyBoolean JAVA_RMI_SERVER_USECODEBASEONLY = new PAPropertyBoolean(
-        "java.rmi.server.useCodebaseOnly", true);
+            "java.rmi.server.useCodebaseOnly", true);
 
     /**
      * Sockets used by the RMI remote object factory connect to the remote server
@@ -301,26 +360,26 @@ public class CentralPAPropertyRepository implements PAPropertiesLoaderSPI {
      * The connection will then block until established or an error occurs.
      */
     static public PAPropertyInteger PA_RMI_CONNECT_TIMEOUT = new PAPropertyInteger(
-        "proactive.rmi.connect_timeout", false);
+            "proactive.rmi.connect_timeout", false);
 
     static public PAPropertyString PA_CODEBASE = new PAPropertyString("proactive.codebase", true);
 
     static public PAPropertyBoolean PA_CLASSLOADING_USEHTTP = new PAPropertyBoolean(
-        "proactive.classloading.useHTTP", false, true);
+            "proactive.classloading.useHTTP", false, true);
     /* ------------------------------------
      *  HTTP
      */
 
     /**
      * Assigns a TCP port to XML-HTTP
-     *
+     * <p/>
      * this property identifies the default port for the xml-http protocol
      */
     static public PAPropertyInteger PA_XMLHTTP_PORT = new PAPropertyInteger("proactive.http.port", false);
 
     /**
      * Jetty configuration file
-     *
+     * <p/>
      * Jetty can be configured by providing a
      * <a  href="http://docs.codehaus.org/display/JETTY/jetty.xml">jetty.xml</a>
      * file. Click
@@ -335,99 +394,126 @@ public class CentralPAPropertyRepository implements PAPropertiesLoaderSPI {
      * The connection will then block until established or an error occurs.
      */
     static public PAPropertyInteger PA_HTTP_CONNECT_TIMEOUT = new PAPropertyInteger(
-        "proactive.http.connect_timeout", false);
+            "proactive.http.connect_timeout", false);
 
     /* ------------------------------------
      *  RMISSH
      */
 
-    /** this property identifies the location of RMISSH key directory */
+    /**
+     * this property identifies the location of RMISSH key directory
+     */
     static public PAPropertyString PA_RMISSH_KEY_DIR = new PAPropertyString(
-        "proactive.communication.rmissh.key_directory", false);
+            "proactive.communication.rmissh.key_directory", false);
 
-    /** this property identifies that when using SSH tunneling, a normal connection should be tried before tunneling */
+    /**
+     * this property identifies that when using SSH tunneling, a normal connection should be tried before tunneling
+     */
     static public PAPropertyBoolean PA_RMISSH_TRY_NORMAL_FIRST = new PAPropertyBoolean(
-        "proactive.communication.rmissh.try_normal_first", false, false);
+            "proactive.communication.rmissh.try_normal_first", false, false);
 
-    /** this property identifies the SSH garbage collector period
-     *
+    /**
+     * this property identifies the SSH garbage collector period
+     * <p/>
      * If set to 0, tunnels and connections are not garbage collected
      */
     static public PAPropertyInteger PA_RMISSH_GC_PERIOD = new PAPropertyInteger(
-        "proactive.communication.rmissh.gc_period", false);
+            "proactive.communication.rmissh.gc_period", false);
 
-    /** this property identifies the maximum idle time before a SSH tunnel or a connection is garbage collected */
+    /**
+     * this property identifies the maximum idle time before a SSH tunnel or a connection is garbage collected
+     */
     static public PAPropertyInteger PA_RMISSH_GC_IDLETIME = new PAPropertyInteger(
-        "proactive.communication.rmissh.gc_idletime", false);
+            "proactive.communication.rmissh.gc_idletime", false);
 
-    /** this property identifies the know hosts file location when using ssh tunneling
-     *  if undefined, the default value is user.home property concatenated to SSH_TUNNELING_DEFAULT_KNOW_HOSTS
+    /**
+     * this property identifies the know hosts file location when using ssh tunneling
+     * if undefined, the default value is user.home property concatenated to SSH_TUNNELING_DEFAULT_KNOW_HOSTS
      */
     static public PAPropertyString PA_RMISSH_KNOWN_HOSTS = new PAPropertyString(
-        "proactive.communication.rmissh.known_hosts", false);
+            "proactive.communication.rmissh.known_hosts", false);
 
-    /** Sock connect timeout, in ms
-     *
+    /**
+     * Sock connect timeout, in ms
+     * <p/>
      * The timeout to be used when a SSH Tunnel is opened. 0 is interpreted
      * as an infinite timeout. This timeout is also used for plain socket when try_normal_first is set to true
      *
      * @see Socket
      */
     static public PAPropertyInteger PA_RMISSH_CONNECT_TIMEOUT = new PAPropertyInteger(
-        "proactive.communication.rmissh.connect_timeout", false);
+            "proactive.communication.rmissh.connect_timeout", false);
 
     // Not documented, temporary workaround until 4.3.0
     static public PAPropertyString PA_RMISSH_REMOTE_USERNAME = new PAPropertyString(
-        "proactive.communication.rmissh.username", false);
+            "proactive.communication.rmissh.username", false);
 
     // Not documented, temporary workaround until 4.3.0
     static public PAPropertyInteger PA_RMISSH_REMOTE_PORT = new PAPropertyInteger(
-        "proactive.communication.rmissh.port", false);
+            "proactive.communication.rmissh.port", false);
 
     /* ------------------------------------
      *  REMOTE OBJECT - MULTI-PROTOCOL
      */
 
-    /** Expose object using these protocols in addition to the default one (protocols separated by comma) */
+    /**
+     * Expose object using these protocols in addition to the default one (protocols separated by comma)
+     */
     // The list of additional protocols must not contain duplicates nor the main protocol
     public static PAPropertyList PA_COMMUNICATION_ADDITIONAL_PROTOCOLS = new PAPropertyList(
-        "proactive.communication.additional_protocols", ",", false,
-        CentralPAPropertyRepositoryUtils.ADDITIONAL_PROTOCOLS_VALIDATOR, "");
+            "proactive.communication.additional_protocols", ",", false,
+            CentralPAPropertyRepositoryUtils.ADDITIONAL_PROTOCOLS_VALIDATOR, "");
 
-    /** Impose a static order for protocols selection, this order will supersede the benchmark order, if benchmark is
-     * activated (The list of protocols must not contain duplicate elements) */
+    /**
+     * Impose a static order for protocols selection, this order will supersede the benchmark order, if benchmark is
+     * activated (The list of protocols must not contain duplicate elements)
+     */
     public static PAPropertyList PA_COMMUNICATION_PROTOCOLS_ORDER = new PAPropertyList(
-        "proactive.communication.protocols.order", ",", false, CentralPAPropertyRepositoryUtils.IS_SET);
+            "proactive.communication.protocols.order", ",", false, CentralPAPropertyRepositoryUtils.IS_SET);
 
-    /** Activate the protocol benchmark, false by default */
+    /**
+     * Activate the protocol benchmark, false by default
+     */
     public static PAPropertyBoolean PA_BENCHMARK_ACTIVATE = new PAPropertyBoolean(
-        "proactive.communication.benchmark.activate", false, false);
+            "proactive.communication.benchmark.activate", false, false);
 
-    /** Specify a parameter for benchmark */
+    /**
+     * Specify a parameter for benchmark
+     */
     public static PAPropertyString PA_BENCHMARK_PARAMETER = new PAPropertyString(
-        "proactive.communication.benchmark.parameter", false);
+            "proactive.communication.benchmark.parameter", false);
 
-    /** The class to use for doing remoteObject Benchmark, must implement BenchmarkObject */
+    /**
+     * The class to use for doing remoteObject Benchmark, must implement BenchmarkObject
+     */
     public static PAPropertyString PA_BENCHMARK_CLASS = new PAPropertyString(
-        "proactive.communication.benchmark.class", false,
-        "org.objectweb.proactive.core.remoteobject.benchmark.SelectionOnly");
+            "proactive.communication.benchmark.class", false,
+            "org.objectweb.proactive.core.remoteobject.benchmark.SelectionOnly");
 
-    /** time waited before two benchmarks */
+    /**
+     * time waited before two benchmarks
+     */
     public static PAPropertyLong PA_BENCHMARK_PERIOD = new PAPropertyLong(
-        "proactive.communication.benchmark.period", false, 600000L);
+            "proactive.communication.benchmark.period", false, 600000L);
 
     /* ------------------------------------
      *  MESSAGE TAGGING
      */
-    /** Set the max period for LocalMemoryTag lease time */
+    /**
+     * Set the max period for LocalMemoryTag lease time
+     */
     static public PAPropertyInteger PA_MAX_MEMORY_TAG_LEASE = new PAPropertyInteger(
-        "proactive.tagmemory.lease.max", false, 60);
+            "proactive.tagmemory.lease.max", false, 60);
 
-    /** Set the Period of the running thread for tag memory leasing check */
+    /**
+     * Set the Period of the running thread for tag memory leasing check
+     */
     static public PAPropertyInteger PA_MEMORY_TAG_LEASE_PERIOD = new PAPropertyInteger(
-        "proactive.tagmemory.lease.period", false, 21);
+            "proactive.tagmemory.lease.period", false, 21);
 
-    /** Enable or disable the Distributed Service ID Tag */
+    /**
+     * Enable or disable the Distributed Service ID Tag
+     */
     static public PAPropertyBoolean PA_TAG_DSF = new PAPropertyBoolean("proactive.tag.dsf", false, false);
 
     /* ------------------------------------
@@ -439,26 +525,26 @@ public class CentralPAPropertyRepository implements PAPropertiesLoaderSPI {
      * on a Node to handle file transfer requests in parallel.
      */
     static public PAPropertyInteger PA_FILETRANSFER_MAX_SERVICES = new PAPropertyInteger(
-        "proactive.filetransfer.services_number", false, 16);
+            "proactive.filetransfer.services_number", false, 16);
 
     /**
      * When sending a file, the maximum number of file blocks (parts) that can
      * be sent asynchronously before blocking for their arrival.
      */
     static public PAPropertyInteger PA_FILETRANSFER_MAX_SIMULTANEOUS_BLOCKS = new PAPropertyInteger(
-        "proactive.filetransfer.blocks_number", false, 8);
+            "proactive.filetransfer.blocks_number", false, 8);
 
     /**
      * The size, in [KB], of file blocks (parts) used to send files.
      */
     static public PAPropertyInteger PA_FILETRANSFER_MAX_BLOCK_SIZE = new PAPropertyInteger(
-        "proactive.filetransfer.blocks_size_kb", false, 512);
+            "proactive.filetransfer.blocks_size_kb", false, 512);
 
     /**
      * The size, in [KB], of the buffers to use when reading and writing a file.
      */
     static public PAPropertyInteger PA_FILETRANSFER_MAX_BUFFER_SIZE = new PAPropertyInteger(
-        "proactive.filetransfer.buffer_size_kb", false, 256);
+            "proactive.filetransfer.buffer_size_kb", false, 256);
 
     // -------------- DATA SPACES
 
@@ -467,14 +553,14 @@ public class CentralPAPropertyRepository implements PAPropertiesLoaderSPI {
      * used on host, this property and/or {@link #PA_DATASPACES_SCRATCH_PATH} should be set.
      */
     static public PAPropertyList PA_DATASPACES_SCRATCH_URLS = new PAPropertyList(
-        "proactive.dataspaces.scratch_urls", ",", false);
+            "proactive.dataspaces.scratch_urls", ",", false);
 
     /**
      * This property indicates a location of the scratch data space. If scratch is going to be used
      * on host, this property and/or {@link #PA_DATASPACES_SCRATCH_URLS} should be set.
      */
     static public PAPropertyString PA_DATASPACES_SCRATCH_PATH = new PAPropertyString(
-        "proactive.dataspaces.scratch_path", false);
+            "proactive.dataspaces.scratch_path", false);
 
     // -------------- VFS PROVIDER
 
@@ -483,37 +569,39 @@ public class CentralPAPropertyRepository implements PAPropertiesLoaderSPI {
      * all unused streams open trough file system server interface.
      */
     static public PAPropertyInteger PA_VFSPROVIDER_SERVER_STREAM_AUTOCLOSE_CHECKING_INTERVAL_MILLIS = new PAPropertyInteger(
-        "proactive.vfsprovider.server.stream_autoclose_checking_millis", false);
+            "proactive.vfsprovider.server.stream_autoclose_checking_millis", false);
 
     /**
      * This property indicates a period after that a stream is perceived as unused and therefore can
      * be closed by auto closing mechanism.
      */
     static public PAPropertyInteger PA_VFSPROVIDER_SERVER_STREAM_OPEN_MAXIMUM_PERIOD_MILLIS = new PAPropertyInteger(
-        "proactive.vfsprovider.server.stream_open_maximum_period_millis", false);
+            "proactive.vfsprovider.server.stream_open_maximum_period_millis", false);
 
     // -------------- Misc
 
     /**
      * Indicates if a Runtime is running a functional test
-     *
+     * <p/>
      * <strong>Internal use</strong>
      * This property is set to true by the functional test framework. JVM to be killed
      * after a functional test are found by using this property
      */
     static public PAPropertyBoolean PA_TEST = new PAPropertyBoolean("proactive.test", false);
 
-    /** Duration of each performance test in ms */
+    /**
+     * Duration of each performance test in ms
+     */
     static public PAPropertyInteger PA_TEST_PERF_DURATION = new PAPropertyInteger(
-        "proactive.test.perf.duration", false, 30000);
+            "proactive.test.perf.duration", false, 30000);
 
     /**
      * Functional test timeout in ms
-     *
+     * <p/>
      * If 0 no timeout.
      */
     static public PAPropertyInteger PA_TEST_TIMEOUT = new PAPropertyInteger("proactive.test.timeout", false,
-        300000);
+            300000);
 
     /**
      * TODO vlegrand Describe this property
@@ -527,62 +615,61 @@ public class CentralPAPropertyRepository implements PAPropertiesLoaderSPI {
      * by the reference on the active object using <code>PAActiveObject.getStubOnThis()</code>
      */
     static public PAPropertyBoolean PA_IMPLICITGETSTUBONTHIS = new PAPropertyBoolean(
-        "proactive.implicitgetstubonthis", false, false);
+            "proactive.implicitgetstubonthis", false, false);
 
     /**
      * on unix system, define the shell that the GCM deployment invokes when creating new runtimes.
      */
     static public PAPropertyString PA_GCMD_UNIX_SHELL = new PAPropertyString("proactive.gcmd.unix.shell",
-        false, "/bin/sh");
+            false, "/bin/sh");
 
     /**
      * if true, write the bytecode of the generated stub on the disk
-     *
      */
     static public PAPropertyBoolean PA_MOP_WRITESTUBONDISK = new PAPropertyBoolean(
-        "proactive.mop.writestubondisk", false, false);
+            "proactive.mop.writestubondisk", false, false);
 
     /**
-      * Specifies the location where to write the classes generated
-      * using the mop
-      */
+     * Specifies the location where to write the classes generated
+     * using the mop
+     */
     static public PAPropertyString PA_MOP_GENERATEDCLASSES_DIR = new PAPropertyString(
-        "proactive.mop.generatedclassesdir", false);
+            "proactive.mop.generatedclassesdir", false);
 
     /**
      * activate or not the ping feature in ProActive -- each time a runtime
      * starts it pings a given web server.
      */
     static public PAPropertyBoolean PA_RUNTIME_PING = new PAPropertyBoolean("proactive.runtime.ping", false,
-        true);
+            true);
     /**
      * the url to ping
      */
     static public PAPropertyString PA_RUNTIME_PING_URL = new PAPropertyString("proactive.runtime.ping.url",
-        false, "http://pinging.activeeon.com/ping.php");
+            false, "http://pinging.activeeon.com/ping.php");
 
     /**
      * Add Runtime the ability to broadcast their presence on the network
      */
     static public PAPropertyBoolean PA_RUNTIME_BROADCAST = new PAPropertyBoolean(
-        "proactive.runtime.broadcast", false, false);
+            "proactive.runtime.broadcast", false, false);
     /**
      * the address to use by the broadcast sockets
      */
     static public PAPropertyString PA_RUNTIME_BROADCAST_ADDRESS = new PAPropertyString(
-        "proactive.runtime.broadcast.address", false, "230.0.1.1");
+            "proactive.runtime.broadcast.address", false, "230.0.1.1");
 
     /**
      * the port to use by the broadcast sockets
      */
     static public PAPropertyInteger PA_RUNTIME_BROADCAST_PORT = new PAPropertyInteger(
-        "proactive.runtime.broadcast.port", false, 4554);
+            "proactive.runtime.broadcast.port", false, 4554);
 
     /**
      * the address to use by the broadcast sockets
      */
     static public PAPropertyString PA_RUNTIME_BROADCAST_CALLBACK_CLASS = new PAPropertyString(
-        "proactive.runtime.broadcast.callback.class", false,
-        "org.objectweb.proactive.core.runtime.broadcast.BTCallbackDefaultImpl");
+            "proactive.runtime.broadcast.callback.class", false,
+            "org.objectweb.proactive.core.runtime.broadcast.BTCallbackDefaultImpl");
 
 }

--- a/programming-core/src/main/java/org/objectweb/proactive/core/util/ProActiveInet.java
+++ b/programming-core/src/main/java/org/objectweb/proactive/core/util/ProActiveInet.java
@@ -36,33 +36,34 @@
  */
 package org.objectweb.proactive.core.util;
 
-import java.net.Inet6Address;
-import java.net.InetAddress;
-import java.net.NetworkInterface;
-import java.net.SocketException;
-import java.net.UnknownHostException;
-import java.util.Enumeration;
-import java.util.LinkedList;
-import java.util.List;
-
+import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
 import org.objectweb.proactive.core.config.CentralPAPropertyRepository;
 import org.objectweb.proactive.core.util.log.Loggers;
 import org.objectweb.proactive.core.util.log.ProActiveLogger;
 
+import java.net.*;
+import java.nio.channels.SocketChannel;
+import java.util.*;
+import java.util.concurrent.*;
 
-/** Provide the local InetAddress to be used by ProActive
- *  
- * Expected behavior of this class is described in the ProActive manual, chapter "ProActive basic configuration"  
+
+/**
+ * Provide the local InetAddress to be used by ProActive
+ * <p/>
+ * Expected behavior of this class is described in the ProActive manual, chapter "ProActive basic configuration"
  */
 public class ProActiveInet {
     static private Logger logger = ProActiveLogger.getLogger(Loggers.CONFIGURATION_NETWORK);
 
-    final static private ProActiveInet instance = new ProActiveInet();
+    static private ProActiveInet instance = null;
 
     final private InetAddress electedAddress;
 
     static public ProActiveInet getInstance() {
+        if (instance == null) {
+            instance = new ProActiveInet();
+        }
         return instance;
     }
 
@@ -70,13 +71,13 @@ public class ProActiveInet {
         electedAddress = electAnAddress();
 
         if (electedAddress == null) {
-            logger.error("No local Inet Address found. Exiting");
+            logger.error("No suitable IP address found.");
         }
     }
 
     /**
      * Returns the inet address used by the local ProActive Runtime
-     * 
+     *
      * @return
      */
     public InetAddress getInetAddress() {
@@ -87,7 +88,7 @@ public class ProActiveInet {
         return electedAddress;
     }
 
-    public List<String> listAllInetAddress() {
+    public static List<String> listAllInetAddress() {
         LinkedList<String> ret = new LinkedList<String>();
 
         Enumeration<NetworkInterface> nis;
@@ -99,20 +100,36 @@ public class ProActiveInet {
                 StringBuilder sb = new StringBuilder();
                 sb.append(ni.getName());
                 sb.append("\t");
-                sb.append("MAC n/a");
-                sb.append("\t");
+                sb.append("MAC: ");
+                byte[] mac = ni.getHardwareAddress();
+                if (mac != null) {
+                    StringBuilder sbmac = new StringBuilder();
+                    for (int i = 0; i < mac.length; i++) {
+                        sbmac.append(String.format("%02X%s", mac[i], (i < mac.length - 1) ? "-" : ""));
+                    }
+                    sb.append(sbmac);
+                } else {
+                    sb.append("N/A");
+                }
 
                 Enumeration<InetAddress> ias = ni.getInetAddresses();
                 while (ias.hasMoreElements()) {
+                    sb.append("\t");
                     InetAddress ia = ias.nextElement();
-
+                    if (ia instanceof Inet6Address) {
+                        sb.append("IPV6: ");
+                    } else {
+                        sb.append("IP: ");
+                    }
                     sb.append(ia.getHostAddress());
-                    sb.append(" ");
                 }
+
                 ret.add(sb.toString());
+
+
             }
         } catch (SocketException e) {
-            logger.info("Failed to find a suitable InetAddress", e);
+            logger.info("Error occurred when listing all InetAddresses", e);
         }
 
         return ret;
@@ -120,12 +137,12 @@ public class ProActiveInet {
 
     /**
      * Returns the host name of the local ProActive inet address
-     * 
-     * If {@link CentralPAPropertyRepository.PA_USE_IP_ADDRESS} is set then the IP address is
+     * <p/>
+     * If {@link CentralPAPropertyRepository#PA_NET_USE_IP_ADDRESS} is set then the IP address is
      * returned instead of an FQDN
-     * 
+     *
      * @return
-     * @see PAProperties
+     * @see CentralPAPropertyRepository
      */
     public String getHostname() {
         return URIBuilder.getHostNameorIP(getInetAddress());
@@ -135,43 +152,19 @@ public class ProActiveInet {
         InetAddress ia = null;
 
         if (defaultBehavior()) {
-            logger.debug("Using default algorithm to elected an IP address");
+            logger.debug("Using default algorithm to elect an IP address");
             ia = getDefaultInterface();
         } else {
-            // Follow the user defined rules
-            if (CentralPAPropertyRepository.PA_HOSTNAME.isSet()) {
-                logger.debug(CentralPAPropertyRepository.PA_HOSTNAME.getName() +
+            // Force a specific address
+            logger.debug(CentralPAPropertyRepository.PA_HOSTNAME.getName() +
                     " defined. Using getByName() to elected an IP address");
-                // return the result of getByName
-                try {
-                    ia = InetAddress.getByName(CentralPAPropertyRepository.PA_HOSTNAME.getValue());
-                } catch (UnknownHostException e) {
-                    logger.info(CentralPAPropertyRepository.PA_HOSTNAME.getName() +
+            // return the result of getByName
+            try {
+                ia = InetAddress.getByName(CentralPAPropertyRepository.PA_HOSTNAME.getValue());
+            } catch (UnknownHostException e) {
+                logger.error(CentralPAPropertyRepository.PA_HOSTNAME.getName() +
                         " is set, but no IP address is bound to this hostname");
-                }
-            } else {
-                logger.debug("At least one proactive.net.* property defined. Using the matching algorithm to elect an IP address");
-                // Use the filter algorithm
-                if (ia == null) {
-                    List<InetAddress> l;
-                    l = getAllInetAddresses();
-                    l = filterByNetmask(l);
-                    l = filterLoopback(l);
-                    l = filterPrivate(l);
-
-                    for (InetAddress addr : l) {
-
-                        if (CentralPAPropertyRepository.PA_NET_DISABLE_IPv6.isTrue() &&
-                            addr instanceof Inet6Address) {
-                            continue;
-                        }
-
-                        ia = addr;
-                        break;
-                    }
-                }
             }
-
         }
 
         return ia;
@@ -179,78 +172,103 @@ public class ProActiveInet {
 
     /**
      * Elects the default {@link InetAddress}.
-     * 
+     * <p/>
      * A first match algorithm is used:
      * <ol>
      * <li>Public IP address</li>
      * <li>Private IP address</li>
      * <li>loopback address</li>
      * </ol>
-     * 
+     * <p/>
+     * Eventually the interface which has the fastest internet connection can be chosen if the following property is enabled:
+     * {@link CentralPAPropertyRepository#PA_NET_FASTEST_CONNECTION}
+     * <p/>
      * IPv6 address can enabled/disabled with the
-     * {@link PAProperties#PA_NET_DISABLE_IPv6} property.
+     * {@link CentralPAPropertyRepository#PA_NET_DISABLE_IPv6} property.
      */
     private InetAddress getDefaultInterface() {
-        List<InetAddress> ias = getAllInetAddresses();
+        List<InetAddress> ias = getEligibleAdresses();
 
-        // Search for a public IPv4 address
-        for (InetAddress ia : ias) {
-            if (ia.isLoopbackAddress())
-                continue;
-            if (ia.isSiteLocalAddress())
-                continue;
-            if (CentralPAPropertyRepository.PA_NET_DISABLE_IPv6.isTrue() && ia instanceof Inet6Address)
-                continue;
+        if (ias.size() > 0) {
 
-            return ia;
-        }
+            if (CentralPAPropertyRepository.PA_NET_FASTEST_CONNECTION.isSet() && CentralPAPropertyRepository.PA_NET_FASTEST_CONNECTION.isTrue()) {
+                logger.debug(
+                        "Property proactive.net.fastest.connection is set to true, compute now Internet connection delay for all interfaces...");
+                InetAddress fastest = selectFastestConnectionToServer(ias);
+                if (fastest != null) {
+                    return fastest;
+                }
+            }
 
-        // Search for a private IPv4 address
-        for (InetAddress ia : ias) {
-            if (ia.isLoopbackAddress())
-                continue;
-            if (CentralPAPropertyRepository.PA_NET_DISABLE_IPv6.isTrue() && ia instanceof Inet6Address)
-                continue;
-
-            return ia;
-        }
-
-        // Search for a loopback address
-        for (InetAddress ia : ias) {
-            if (CentralPAPropertyRepository.PA_NET_DISABLE_IPv6.isTrue() && ia instanceof Inet6Address)
-                continue;
-
-            return ia;
+            return ias.get(0);
         }
 
         return null;
     }
 
     /**
-     * Returns true if a property that can affect interface binding is set.
+     * returns all eligible {@link InetAddress}.
+     * <p/>
+     * The list is sorted using the following order:
+     * <ol>
+     * <li>Public IP address</li>
+     * <li>Private IP address</li>
+     * <li>loopback address</li>
+     * </ol>
+     * <p/>
+     * IPv6 address can enabled/disabled with the
+     * {@link CentralPAPropertyRepository#PA_NET_DISABLE_IPv6} property.
+     */
+    public List<InetAddress> getEligibleAdresses() {
+        List<InetAddress> ias = getAllInetAddresses();
+        LinkedHashSet<InetAddress> result = new LinkedHashSet<InetAddress>();
+        // Search for a public address
+        for (InetAddress ia : ias) {
+            if (ia.isLoopbackAddress())
+                continue;
+            if (ia.isLinkLocalAddress())
+                continue;
+            if (ia.isSiteLocalAddress())
+                continue;
+            result.add(ia);
+        }
+
+        // Search for a private address
+        for (InetAddress ia : ias) {
+            if (ia.isLoopbackAddress())
+                continue;
+            if (ia.isLinkLocalAddress())
+                continue;
+            result.add(ia);
+        }
+
+        // Search for a loopback address
+        for (InetAddress ia : ias) {
+            result.add(ia);
+        }
+
+        return new ArrayList<>(result);
+    }
+
+
+    /**
+     * Returns true if the hostname property is set (force binding).
      * False otherwise
      */
     private boolean defaultBehavior() {
         if (CentralPAPropertyRepository.PA_HOSTNAME.isSet())
             return false;
 
-        if (CentralPAPropertyRepository.PA_NET_NOLOOPBACK.isSet())
-            return false;
-
-        if (CentralPAPropertyRepository.PA_NET_NOPRIVATE.isSet())
-            return false;
-
-        if (CentralPAPropertyRepository.PA_NET_NETMASK.isSet())
-            return false;
-
-        if (CentralPAPropertyRepository.PA_NET_INTERFACE.isSet())
-            return false;
-
         return true;
     }
 
-    private List<InetAddress> getAllInetAddresses() {
-        LinkedList<InetAddress> ret = new LinkedList<InetAddress>();
+    /**
+     * Return all inet addresses
+     *
+     * @return
+     */
+    private static List<InetAddress> getAllInetAddresses() {
+        List<InetAddress> ret = new LinkedList<InetAddress>();
 
         String intf = CentralPAPropertyRepository.PA_NET_INTERFACE.getValue();
 
@@ -261,29 +279,42 @@ public class ProActiveInet {
                 NetworkInterface ni = nis.nextElement();
 
                 if (intf != null && !ni.getName().equals(intf)) {
-                    // Skip this interface
+                    // Skip this interface if it's not the one selected
+                    continue;
+                }
+
+                if (!ni.isUp()) {
+                    // Skip this interface if it's disabled
                     continue;
                 }
 
                 Enumeration<InetAddress> ias = ni.getInetAddresses();
-                while (ias.hasMoreElements()) {
-                    InetAddress ia = ias.nextElement();
+                List<InetAddress> ial = Collections.list(ias);
 
-                    ret.add(ia);
-                }
+                ret.addAll(ial);
             }
         } catch (SocketException e) {
             logger.info("Failed to find a suitable InetAddress", e);
         }
 
-        return ret;
+        ret = filterIPv6(ret);
+        ret = filterLinkLocal(ret);
+        ret = filterByNetmask(ret);
+        ret = filterLoopback(ret);
+        ret = filterPrivate(ret);
+
+        List<InetAddress> iaspref = new LinkedList<>(ret);
+        sortInetAddresses(iaspref);
+
+        return iaspref;
     }
 
-    private List<InetAddress> filterPrivate(List<InetAddress> l) {
+
+    private static List<InetAddress> filterPrivate(List<InetAddress> l) {
         if (!CentralPAPropertyRepository.PA_NET_NOPRIVATE.isSet() ||
-            !CentralPAPropertyRepository.PA_NET_NOPRIVATE.isTrue()) {
+                !CentralPAPropertyRepository.PA_NET_NOPRIVATE.isTrue()) {
             // All InetAddress match
-            return new LinkedList<InetAddress>(l);
+            return l;
         }
 
         List<InetAddress> ret = new LinkedList<InetAddress>();
@@ -294,15 +325,33 @@ public class ProActiveInet {
                 logger.debug("Discarded " + ia + " because of the no private criteria");
             }
         }
+        return ret;
+    }
+
+    private static List<InetAddress> filterLinkLocal(List<InetAddress> l) {
+        if (!CentralPAPropertyRepository.PA_NET_NOLINKLOCAL.isSet() ||
+                !CentralPAPropertyRepository.PA_NET_NOLINKLOCAL.isTrue()) {
+            // All InetAddress match
+            return l;
+        }
+
+        List<InetAddress> ret = new LinkedList<>();
+        for (InetAddress ia : l) {
+            if (!ia.isLinkLocalAddress()) {
+                ret.add(ia);
+            } else {
+                logger.debug("Discarded " + ia + " because it's a link local address");
+            }
+        }
 
         return ret;
     }
 
-    private List<InetAddress> filterLoopback(List<InetAddress> l) {
+    private static List<InetAddress> filterLoopback(List<InetAddress> l) {
         if (!CentralPAPropertyRepository.PA_NET_NOLOOPBACK.isSet() ||
-            !CentralPAPropertyRepository.PA_NET_NOLOOPBACK.isTrue()) {
+                !CentralPAPropertyRepository.PA_NET_NOLOOPBACK.isTrue()) {
             // All InetAddress match
-            return new LinkedList<InetAddress>(l);
+            return l;
         }
 
         List<InetAddress> ret = new LinkedList<InetAddress>();
@@ -317,10 +366,112 @@ public class ProActiveInet {
         return ret;
     }
 
-    private List<InetAddress> filterByNetmask(List<InetAddress> l) {
+
+    /**
+     * Sort addresses according to IPv4 / IPv6 preferences
+     *
+     * @param iaList
+     */
+    private static void sortInetAddresses(List<InetAddress> iaList) {
+        // By default we prefer IPv4 addresses, unless the prefer_ipv6_address is set
+        final int cmpIp4Ip6 = ((CentralPAPropertyRepository.PREFER_IPV6_ADDRESSES.isSet() && CentralPAPropertyRepository.PREFER_IPV6_ADDRESSES.isTrue())) ? 1 : -1;
+        Collections.sort(iaList, new Comparator<InetAddress>() {
+            @Override
+            public int compare(InetAddress o1, InetAddress o2) {
+                boolean o1i4 = (o1 instanceof Inet4Address);
+                boolean o2i4 = (o2 instanceof Inet4Address);
+                if ((o1i4) && (o2i4)) {
+                    return 0;
+                } else if ((!o1i4) && (!o2i4)) {
+                    return 0;
+                } else if ((o1i4) && (!o2i4)) {
+                    return cmpIp4Ip6;
+                } else {
+                    // ((!o1i4) && (o2i4))
+                    return -cmpIp4Ip6;
+                }
+            }
+        });
+    }
+
+    /**
+     * Select the address which has the fastest connection to the given server
+     *
+     * @param listAdresses
+     * @return the elected address or null if no address can connect to the given server
+     */
+    private InetAddress selectFastestConnectionToServer(List<InetAddress> listAdresses) {
+
+        ExecutorService service = Executors.newFixedThreadPool(listAdresses.size());
+
+        final int timeout = CentralPAPropertyRepository.PA_NET_FASTEST_CONNECTION_TIMEOUT.getValue();
+        final String serverToConnectTo = CentralPAPropertyRepository.PA_NET_FASTEST_CONNECTION_SERVER.getValue();
+        final int port = CentralPAPropertyRepository.PA_NET_FASTEST_CONNECTION_PORT.getValue();
+
+        final List<Callable<Map.Entry<InetAddress, Integer>>> testConnectionCallables = new ArrayList<>(listAdresses.size());
+
+        for (final InetAddress address : listAdresses) {
+            testConnectionCallables.add(new Callable<Map.Entry<InetAddress, Integer>>() {
+
+                @Override
+                public Map.Entry<InetAddress, Integer> call() throws Exception {
+                    try (SocketChannel socket = SocketChannel.open()) {
+
+                        // again, use a big enough timeout
+                        socket.socket().setSoTimeout(timeout);
+
+                        // bind the socket to your local interface
+                        socket.bind(new InetSocketAddress(address, 0));
+
+                        long start = System.currentTimeMillis();
+
+                        // try to connect to *somewhere*
+                        socket.connect(new InetSocketAddress(serverToConnectTo
+                                , port
+                        ));
+                        long end = System.currentTimeMillis();
+                        return new AbstractMap.SimpleImmutableEntry(address, (int) (end - start));
+                    }
+                }
+            });
+        }
+
+        try {
+            Map.Entry<InetAddress, Integer> fastestAddress = service.invokeAny(testConnectionCallables, (long) timeout * 2, TimeUnit.MILLISECONDS);
+            logger.debug("Fastest address detected : " + fastestAddress.getKey() + " (" + fastestAddress.getValue() + " ms)");
+            return fastestAddress.getKey();
+        } catch (Exception e) {
+            return null;
+        } finally {
+            service.shutdownNow();
+        }
+    }
+
+
+    private static List<InetAddress> filterIPv6(List<InetAddress> l) {
+        if (!CentralPAPropertyRepository.PA_NET_DISABLE_IPv6.isSet() ||
+                !CentralPAPropertyRepository.PA_NET_DISABLE_IPv6.isTrue()) {
+            // All InetAddress match
+            return l;
+        }
+
+        List<InetAddress> ret = new LinkedList<>();
+        for (InetAddress ia : l) {
+            if (!(ia instanceof Inet6Address)) {
+                ret.add(ia);
+            } else {
+                logger.debug("Discarded " + ia + " because it's an IPv6 address");
+            }
+        }
+
+        return ret;
+    }
+
+
+    private static List<InetAddress> filterByNetmask(List<InetAddress> l) {
         if (!CentralPAPropertyRepository.PA_NET_NETMASK.isSet()) {
             // All InetAddress match
-            return new LinkedList<InetAddress>(l);
+            return l;
         }
 
         IPMatcher matcher;
@@ -328,18 +479,18 @@ public class ProActiveInet {
             matcher = new IPMatcher(CentralPAPropertyRepository.PA_NET_NETMASK.getValue());
         } catch (Throwable e) {
             logger.fatal("Invalid format for property " +
-                CentralPAPropertyRepository.PA_NET_NETMASK.getName() + ". Must be xxx.xxx.xxx.xxx/xx");
-            return new LinkedList<InetAddress>();
+                    CentralPAPropertyRepository.PA_NET_NETMASK.getName() + ". Must be xxx.xxx.xxx.xxx/xx");
+            return new LinkedList<>();
         }
 
-        List<InetAddress> ret = new LinkedList<InetAddress>();
+        List<InetAddress> ret = new LinkedList<>();
         for (InetAddress ia : l) {
             if (!(ia instanceof Inet6Address)) {
                 if (matcher.match(ia)) {
                     ret.add(ia);
                 } else {
                     logger.debug("Discarded " + ia +
-                        " because of netmask criteria is not compatible with IPv6");
+                            " because of netmask criteria is not compatible with IPv6");
                 }
             } else {
                 logger.debug("Discarded " + ia + " because of the  netmask criteria");
@@ -415,5 +566,23 @@ public class ProActiveInet {
 
             return tmp;
         }
+    }
+
+    public static void main(String[] args) {
+        if (args.length == 1 && args[0].equals("-debug")) {
+            logger.setLevel(Level.DEBUG);
+        }
+        String nl = System.lineSeparator();
+        System.out.println("Available interfaces: ");
+        for (String itf : listAllInetAddress()) {
+            System.out.println(itf);
+        }
+        ProActiveInet painet = ProActiveInet.getInstance();
+        System.out.println(nl + "Eligible addresses: ");
+        for (InetAddress ia : painet.getEligibleAdresses()) {
+            System.out.println(ia);
+        }
+
+        System.out.println(nl + "Elected address : " + painet.electedAddress);
     }
 }


### PR DESCRIPTION
- Refactored ProActiveInet class to follow the election algorithm even if filters are enabled
- Added a main class to allow checking the result of the address detection from the command line
- Added a method which returns a sorted list of all eligible addresses
- Added a no link-local property (set to true by default) to filter link local addresses as they are non-routable
- Re-enable IPV6 but bind to IPv4 addresses preferably
- Added a "proactive.net.fastest.connection" property, which - when enabled - will automatically select the most "visible" interface.
