### PR TITLE
fix for ow2-proactive/scheduling#2687

### DIFF
--- a/programming-extensions/programming-extension-dataspaces/src/test/java/dataspaces/VFSMountManagerHelperTerminateTest.java
+++ b/programming-extensions/programming-extension-dataspaces/src/test/java/dataspaces/VFSMountManagerHelperTerminateTest.java
@@ -1,0 +1,106 @@
+/*
+ *  *
+ * ProActive Parallel Suite(TM): The Java(TM) library for
+ *    Parallel, Distributed, Multi-Core Computing for
+ *    Enterprise Grids & Clouds
+ *
+ * Copyright (C) 1997-2015 INRIA/University of
+ *                 Nice-Sophia Antipolis/ActiveEon
+ * Contact: proactive@ow2.org or contact@activeeon.com
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation; version 3 of
+ * the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307
+ * USA
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ *
+ *  Initial developer(s):               The ProActive Team
+ *                        http://proactive.inria.fr/team_members.htm
+ *  Contributor(s):
+ *
+ *  * $$ACTIVEEON_INITIAL_DEV$$
+ */
+package dataspaces;
+
+import org.apache.commons.vfs2.FileObject;
+import org.apache.log4j.Level;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Test;
+import org.objectweb.proactive.core.ProActiveException;
+import org.objectweb.proactive.core.config.CentralPAPropertyRepository;
+import org.objectweb.proactive.core.util.log.Loggers;
+import org.objectweb.proactive.core.util.log.ProActiveLogger;
+import org.objectweb.proactive.extensions.dataspaces.vfs.VFSMountManagerHelper;
+import org.objectweb.proactive.extensions.vfsprovider.FileSystemServerDeployer;
+
+import java.io.File;
+import java.util.Arrays;
+
+import static org.junit.Assert.assertTrue;
+
+public class VFSMountManagerHelperTerminateTest {
+
+    private static File spacesDir;
+
+    private static FileSystemServerDeployer server;
+
+    static {
+        CentralPAPropertyRepository.PA_CLASSLOADING_USEHTTP.setValue(false);
+        ProActiveLogger.getLogger(Loggers.DATASPACES).setLevel(Level.DEBUG);
+    }
+
+
+    @Test
+    public void testTerminate() throws Exception {
+
+
+        spacesDir = new File(System.getProperty("java.io.tmpdir"), "ProActive SpaceMountManagerTest");
+
+        if (server == null) {
+            server = new FileSystemServerDeployer("inputserver", spacesDir.toString(), true, true);
+            System.out.println("Started File Server at " + Arrays.toString(server.getVFSRootURLs()));
+        }
+
+        String[] validUrls = server.getVFSRootURLs();
+        for (String validUrl : validUrls) {
+            FileObject mounted = VFSMountManagerHelper.mount(validUrl);
+            Assert.assertTrue(mounted.exists());
+        }
+
+        VFSMountManagerHelper.terminate();
+
+        VFSMountManagerHelper.closeFileSystems(Arrays.asList(validUrls));
+
+        // Ensure that we can regenerate the mount helper
+        for (String validUrl : validUrls) {
+            FileObject mounted = VFSMountManagerHelper.mount(validUrl);
+            Assert.assertTrue(mounted.exists());
+        }
+
+    }
+
+    @AfterClass
+    public static void tearDown() throws ProActiveException {
+        server.terminate();
+
+        VFSMountManagerHelper.terminate();
+
+        if (spacesDir != null && spacesDir.exists()) {
+            assertTrue(vfsprovider.AbstractIOOperationsBase.deleteRecursively(spacesDir));
+            spacesDir = null;
+        }
+    }
+}


### PR DESCRIPTION
A race condition can occur when shutting down the JVM. In that case, the VFSMountManagerHelper shutdown hook can execute concurrently with VFSMountManagerHelper.closeFileSystems. In that case, the vfsManager(VFS:DefaultFileSystemManager) can be closed by the shutdown hook and used later in the closeFileSystems method

This fix is meant to avoid such conflicting states by the following:
- shutdown hook now calls the terminate method which is synchronized.
- this terminate method nullifies the vfsManager field.
- the closeFileSystems method does nothing if the VFSMountManagerHelper is already terminated.
- The VFSMountManagerHelper can still be reused if a new call to mountAny is done, which regenerates the helper.

Added a test to verify that, after the terminate call, the closeFileSystems does not throw a NPE, and the helper can be regenerated with a call to mountAny
