### PR TITLE
change the semantic of getDefaultValue method in ProActive properties

### DIFF
--- a/programming-core/src/main/java/org/objectweb/proactive/core/config/PAProperty.java
+++ b/programming-core/src/main/java/org/objectweb/proactive/core/config/PAProperty.java
@@ -104,7 +104,7 @@ public interface PAProperty {
      * @return
      *    the default value or null.
      */
-    public String getDefaultValue();
+    public String getDefaultValueAsString();
 
     /**
      * Indicates if the property is set.

--- a/programming-core/src/main/java/org/objectweb/proactive/core/config/PAPropertyAlias.java
+++ b/programming-core/src/main/java/org/objectweb/proactive/core/config/PAPropertyAlias.java
@@ -98,8 +98,8 @@ public class PAPropertyAlias implements PAProperty {
     }
 
     @Override
-    public String getDefaultValue() {
-        return this.target.getDefaultValue();
+    public String getDefaultValueAsString() {
+        return this.target.getDefaultValueAsString();
     }
 
     @Override

--- a/programming-core/src/main/java/org/objectweb/proactive/core/config/PAPropertyBoolean.java
+++ b/programming-core/src/main/java/org/objectweb/proactive/core/config/PAPropertyBoolean.java
@@ -60,6 +60,11 @@ public class PAPropertyBoolean extends PAPropertyImpl {
         return Boolean.parseBoolean(str);
     }
 
+    final public boolean getDefaultValue() {
+        String str = super.getDefaultValueAsString();
+        return Boolean.parseBoolean(str);
+    }
+
     final public boolean isTrue() {
         return this.getValue();
     }

--- a/programming-core/src/main/java/org/objectweb/proactive/core/config/PAPropertyImpl.java
+++ b/programming-core/src/main/java/org/objectweb/proactive/core/config/PAPropertyImpl.java
@@ -92,7 +92,7 @@ abstract class PAPropertyImpl implements PAProperty {
     }
 
     @Override
-    public String getDefaultValue() {
+    public String getDefaultValueAsString() {
         return this.defaultValue;
     }
 

--- a/programming-core/src/main/java/org/objectweb/proactive/core/config/PAPropertyInteger.java
+++ b/programming-core/src/main/java/org/objectweb/proactive/core/config/PAPropertyInteger.java
@@ -53,11 +53,20 @@ public class PAPropertyInteger extends PAPropertyImpl {
 
     final public int getValue() {
         String str = super.getValueAsString();
+        return parseValue(str);
+    }
+
+    final public int getDefaultValue() {
+        String str = super.getDefaultValueAsString();
+        return parseValue(str);
+    }
+
+    private int parseValue(String str) {
         try {
             return Integer.parseInt(str);
         } catch (NumberFormatException e) {
             throw new RuntimeException("Invalid value for ProActive property " + super.getAliasedName() +
-                " must be an integer", e);
+                    " must be an integer", e);
         }
     }
 

--- a/programming-core/src/main/java/org/objectweb/proactive/core/config/PAPropertyList.java
+++ b/programming-core/src/main/java/org/objectweb/proactive/core/config/PAPropertyList.java
@@ -79,13 +79,16 @@ public class PAPropertyList extends PAPropertyImpl {
 
     final public List<String> getValue() {
         if (computedValue == null) {
-            computeStringToList();
+            computedValue = computeStringToList(super.getValueAsString());
         }
         return computedValue;
     }
 
-    private void computeStringToList() {
-        String value = super.getValueAsString();
+    final public List<String> getDefaultValue() {
+        return computeStringToList(super.getDefaultValueAsString());
+    }
+
+    private List<String> computeStringToList(String value) {
         if (value != null) {
             ArrayList<String> tmplist = new ArrayList<>();
             for (String val : value.split(Pattern.quote(separator))) {
@@ -97,9 +100,9 @@ public class PAPropertyList extends PAPropertyImpl {
             if (validator != null) {
                 validator.accept(tmplist);
             }
-            computedValue = tmplist;
+            return tmplist;
         } else {
-            computedValue = null;
+            return null;
         }
     }
 
@@ -121,7 +124,7 @@ public class PAPropertyList extends PAPropertyImpl {
 
     final public void setValue(String value) {
         super.internalSetValue(value);
-        computeStringToList();
+        computedValue = computeStringToList(value);
     }
 
     final public void setValue(List<String> value) {

--- a/programming-core/src/main/java/org/objectweb/proactive/core/config/PAPropertyLong.java
+++ b/programming-core/src/main/java/org/objectweb/proactive/core/config/PAPropertyLong.java
@@ -53,11 +53,20 @@ public class PAPropertyLong extends PAPropertyImpl {
 
     final public long getValue() {
         String str = super.getValueAsString();
+        return parseValue(str);
+    }
+
+    final public long getDefaultValue() {
+        String str = super.getDefaultValueAsString();
+        return parseValue(str);
+    }
+
+    private long parseValue(String str) {
         try {
             return Long.parseLong(str);
         } catch (NumberFormatException e) {
             throw new RuntimeException("Invalid value for ProActive property " + super.getAliasedName() +
-                " must be a long", e);
+                    " must be a long", e);
         }
     }
 

--- a/programming-core/src/main/java/org/objectweb/proactive/core/config/PAPropertyString.java
+++ b/programming-core/src/main/java/org/objectweb/proactive/core/config/PAPropertyString.java
@@ -54,6 +54,10 @@ public class PAPropertyString extends PAPropertyImpl {
         return super.getValueAsString();
     }
 
+    final public String getDefaultValue() {
+        return super.getDefaultValueAsString();
+    }
+
     final public void setValue(String value) {
         super.internalSetValue(value);
     }

--- a/programming-core/src/main/java/org/objectweb/proactive/core/config/ProActiveConfiguration.java
+++ b/programming-core/src/main/java/org/objectweb/proactive/core/config/ProActiveConfiguration.java
@@ -36,6 +36,12 @@
  */
 package org.objectweb.proactive.core.config;
 
+import org.apache.log4j.Logger;
+import org.objectweb.proactive.core.config.xml.ProActiveConfigurationParser;
+import org.objectweb.proactive.core.util.log.Loggers;
+import org.objectweb.proactive.core.util.log.ProActiveLogger;
+import org.objectweb.proactive.utils.OperatingSystem;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -44,12 +50,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
-
-import org.objectweb.proactive.core.config.xml.ProActiveConfigurationParser;
-import org.objectweb.proactive.core.util.log.Loggers;
-import org.objectweb.proactive.core.util.log.ProActiveLogger;
-import org.objectweb.proactive.utils.OperatingSystem;
-import org.apache.log4j.Logger;
 
 
 /**
@@ -108,8 +108,8 @@ public class ProActiveConfiguration {
         Map<Class<?>, List<PAProperty>> allProperties = PAProperties.getAllProperties();
         for (List<PAProperty> list : allProperties.values()) {
             for (PAProperty prop : list) {
-                if (prop.getDefaultValue() != null) {
-                    setProperty(prop.getName(), prop.getDefaultValue(), prop.isSystemProperty());
+                if (prop.getDefaultValueAsString() != null) {
+                    setProperty(prop.getName(), prop.getDefaultValueAsString(), prop.isSystemProperty());
                 }
             }
         }

--- a/programming-core/src/test/java/org/objectweb/proactive/core/config/PropertyListTest.java
+++ b/programming-core/src/test/java/org/objectweb/proactive/core/config/PropertyListTest.java
@@ -34,10 +34,10 @@
  */
 package org.objectweb.proactive.core.config;
 
-import java.util.Arrays;
-
 import org.junit.Assert;
 import org.junit.Test;
+
+import java.util.Arrays;
 
 
 /**
@@ -49,10 +49,12 @@ public class PropertyListTest {
 
     @Test
     public void testParseListProperty() {
-        PAPropertyList myProperty = new PAPropertyList("my.property", ",", false);
+        PAPropertyList myProperty = new PAPropertyList("my.property", ",", false, "test,a,value");
         myProperty.setValue("test,a,value");
 
         Assert.assertEquals(Arrays.asList("test", "a", "value"), myProperty.getValue());
+
+        Assert.assertEquals(Arrays.asList("test", "a", "value"), myProperty.getDefaultValue());
 
         myProperty.setValue(Arrays.asList("test", "b", "value"));
         Assert.assertEquals("test,b,value", myProperty.getValueAsString());


### PR DESCRIPTION
- renamed the old semantic to getDefaultValueAsString
- the new getDefaultValue method returns the default value as the expected type (int, long, list, etc)