### PR TITLE
Add adaptative heartbeat timeout mechanism

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -297,7 +297,9 @@ project('programming-extensions:programming-extension-gcmdeployment') {
 project('programming-extensions:programming-extension-pnp') {
     dependencies {
         compile(
-                'io.netty:netty:3.10.4.Final'
+                'io.netty:netty:3.10.4.Final',
+                'com.google.guava:guava:19.0',
+                'org.apache.commons:commons-collections4:4.0'
         )
     }
 }

--- a/programming-core/src/main/java/org/objectweb/proactive/core/remoteobject/RemoteObjectProtocolFactoryRegistry.java
+++ b/programming-core/src/main/java/org/objectweb/proactive/core/remoteobject/RemoteObjectProtocolFactoryRegistry.java
@@ -36,19 +36,18 @@
  */
 package org.objectweb.proactive.core.remoteobject;
 
-import java.util.Enumeration;
-import java.util.Hashtable;
-import java.util.Iterator;
-
-import javax.imageio.spi.ServiceRegistry;
-
+import org.apache.log4j.Logger;
 import org.objectweb.proactive.core.Constants;
 import org.objectweb.proactive.core.remoteobject.http.HTTPRemoteObjectFactory;
 import org.objectweb.proactive.core.remoteobject.rmi.RmiRemoteObjectFactory;
 import org.objectweb.proactive.core.remoteobject.rmissh.RmiSshRemoteObjectFactory;
 import org.objectweb.proactive.core.util.log.Loggers;
 import org.objectweb.proactive.core.util.log.ProActiveLogger;
-import org.apache.log4j.Logger;
+
+import javax.imageio.spi.ServiceRegistry;
+import java.util.Enumeration;
+import java.util.Hashtable;
+import java.util.Iterator;
 
 
 public class RemoteObjectProtocolFactoryRegistry {

--- a/programming-extensions/programming-extension-pnp/src/main/java/org/objectweb/proactive/extensions/pnp/PNPClientHandler.java
+++ b/programming-extensions/programming-extension-pnp/src/main/java/org/objectweb/proactive/extensions/pnp/PNPClientHandler.java
@@ -67,8 +67,6 @@ class PNPClientHandler extends IdleStateAwareChannelHandler {
 
     @Override
     public void messageReceived(ChannelHandlerContext ctx, MessageEvent e) throws Exception {
-        // Must be called ASAP to avoid late heartbeat
-        pnpClientChannel.signalInputMessage();
 
         if (!(e.getMessage() instanceof PNPFrame)) {
             throw new PNPException("Invalid message type " + e.getMessage().getClass().getName());
@@ -80,7 +78,7 @@ class PNPClientHandler extends IdleStateAwareChannelHandler {
                 pnpClientChannel.receiveResponse((PNPFrameCallResponse) msg);
                 break;
             case HEARTBEAT:
-                // OK we already notified the client channel
+                pnpClientChannel.signalHeartBeatMessage(ctx, (PNPFrameHeartbeat) msg);
                 break;
             default:
                 throw new PNPException("Unexpected message type: " + msg);

--- a/programming-extensions/programming-extension-pnp/src/main/java/org/objectweb/proactive/extensions/pnp/PNPConfig.java
+++ b/programming-extensions/programming-extension-pnp/src/main/java/org/objectweb/proactive/extensions/pnp/PNPConfig.java
@@ -59,7 +59,7 @@ final public class PNPConfig implements PAPropertiesLoaderSPI {
     /**
      * The default heartbeat period (in milliseconds)
      *
-     * PNP offers an heartbeat mechanism to detect network failure. If set to 0 hearthbeats are disabled and
+     * PNP offers an heartbeat mechanism to detect network failure. If set to 0 heartbeats are disabled and
      * network failure will not be detected before the TCP timeout which can be quite long.
      *
      * Setting this value too low impacts the network performance. It is not recommended to use a value
@@ -67,7 +67,38 @@ final public class PNPConfig implements PAPropertiesLoaderSPI {
      *
      */
     static final public PAPropertyInteger PA_PNP_DEFAULT_HEARTBEAT = new PAPropertyInteger(
-        "proactive.pnp.default_heartbeat", false, 60 * 1000);
+            "proactive.pnp.default_heartbeat", false, 10 * 1000);
+
+    /**
+     * A factor of the heartbeat period used to detect failure.
+     * The timeout used to detect a failure is set by default to heartbeat_period * factor.
+     * <p>
+     * This timeout is dynamically updated when receiving heartbeats to match the actual network delay observed.
+     * It can never be decreased below the default value: heartbeat_period * factor.
+     * <p>
+     * When the delay between heartbeats increases due to network delay or machine load, then the corresponding timeout will also increase.
+     * Technically, the last heartbeat interval is compared to proactive.pnp.heartbeat_window samples.
+     * If the last interval is bigger than the average, then the timeout will be set to: last_interval * factor,
+     * Otherwise, the timeout will be set to: average * factor
+     * <p>
+     * Thus, the heartbeat_factor property controls the tolerance of the mechanism regarding delay increase.
+     * If the factor is set too low, it can imply that a slight delay will be acknowledged as a network failure.
+     * If the factor is set too high, network failure detection will take a very long time.
+     * <p>
+     * The heartbeat_window property controls the "inertia" at which the timeout will be decreased back to its default value, after a period of increasing delay.
+     * If the heartbeat_window is set too low, then only a few samples will be considered and the timeout will always be set according to the last heartbeat interval.
+     * If the heartbeat_window is set too high, after a long period of network delay increase, the timeout will require the same amount of time to decrease back to its default value.
+     */
+    static final public PAPropertyInteger PA_PNP_HEARTBEAT_FACTOR = new PAPropertyInteger(
+            "proactive.pnp.heartbeat_factor", false, 3);
+    static final public PAPropertyInteger PA_PNP_HEARTBEAT_WINDOW = new PAPropertyInteger(
+            "proactive.pnp.heartbeat_window", false, 5);
+
+    /**
+     * This property is only used for testing purpose, to simulate a server delay
+     */
+    static final public PAPropertyInteger PA_PNP_TEST_RANDOMDELAY = new PAPropertyInteger(
+            "proactive.pnp.test.random_delay", false, 0);
 
     /**
      * Channel garbage collection timeout (in milliseconds)
@@ -81,11 +112,15 @@ final public class PNPConfig implements PAPropertiesLoaderSPI {
     private int port;
     private int idleTimeout;
     private int defaultHeartbeat;
+    private int heartbeatFactor;
+    private int heartbeatWindow;
 
     public PNPConfig() {
-        this.port = 0;
-        this.idleTimeout = 600 * 1000;
-        this.defaultHeartbeat = 60 * 1000;
+        this.port = PA_PNP_PORT.getDefaultValue();
+        this.idleTimeout = PA_PNP_IDLE_TIMEOUT.getDefaultValue();
+        this.defaultHeartbeat = PA_PNP_DEFAULT_HEARTBEAT.getDefaultValue();
+        this.heartbeatFactor = PA_PNP_HEARTBEAT_FACTOR.getDefaultValue();
+        this.heartbeatWindow = PA_PNP_HEARTBEAT_WINDOW.getDefaultValue();
     }
 
     public void setPort(int port) {
@@ -94,6 +129,22 @@ final public class PNPConfig implements PAPropertiesLoaderSPI {
 
     public void setIdleTimeout(int idleTimeout) {
         this.idleTimeout = idleTimeout;
+    }
+
+    public void setHeartbeatFactor(int heartbeatFactor) {
+        this.heartbeatFactor = heartbeatFactor;
+    }
+
+    public int getHeartbeatFactor() {
+        return heartbeatFactor;
+    }
+
+    public void setHeartbeatWindow(int heartbeatWindow) {
+        this.heartbeatWindow = heartbeatWindow;
+    }
+
+    public int getHeartbeatWindow() {
+        return heartbeatWindow;
     }
 
     public void setDefaultHeartbeat(int defaultHeartbeat) {

--- a/programming-extensions/programming-extension-pnp/src/main/java/org/objectweb/proactive/extensions/pnp/PNPROMessageRequest.java
+++ b/programming-extensions/programming-extension-pnp/src/main/java/org/objectweb/proactive/extensions/pnp/PNPROMessageRequest.java
@@ -36,16 +36,16 @@
  */
 package org.objectweb.proactive.extensions.pnp;
 
-import java.io.IOException;
-import java.io.Serializable;
-import java.net.URI;
-
 import org.objectweb.proactive.core.body.future.MethodCallResult;
 import org.objectweb.proactive.core.body.request.Request;
 import org.objectweb.proactive.core.exceptions.IOException6;
 import org.objectweb.proactive.core.remoteobject.InternalRemoteRemoteObject;
 import org.objectweb.proactive.core.remoteobject.SynchronousReplyImpl;
 import org.objectweb.proactive.core.util.URIBuilder;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.net.URI;
 
 
 /** Represent a {@link Request} */

--- a/programming-extensions/programming-extension-pnp/src/main/java/org/objectweb/proactive/extensions/pnp/PNPRemoteObjectFactory.java
+++ b/programming-extensions/programming-extension-pnp/src/main/java/org/objectweb/proactive/extensions/pnp/PNPRemoteObjectFactory.java
@@ -50,6 +50,8 @@ public class PNPRemoteObjectFactory extends PNPRemoteObjectFactoryAbstract {
         config.setPort(PNPConfig.PA_PNP_PORT.getValue());
         config.setIdleTimeout(PNPConfig.PA_PNP_IDLE_TIMEOUT.getValue());
         config.setDefaultHeartbeat(PNPConfig.PA_PNP_DEFAULT_HEARTBEAT.getValue());
+        config.setHeartbeatFactor(PNPConfig.PA_PNP_HEARTBEAT_FACTOR.getValue());
+        config.setHeartbeatWindow(PNPConfig.PA_PNP_HEARTBEAT_WINDOW.getValue());
 
         final PNPRemoteObjectFactoryBackend rof;
         rof = new PNPRemoteObjectFactoryBackend(PROTO_ID, config, null);

--- a/programming-extensions/programming-extension-pnp/src/main/java/org/objectweb/proactive/extensions/pnp/PNPTimeoutHandler.java
+++ b/programming-extensions/programming-extension-pnp/src/main/java/org/objectweb/proactive/extensions/pnp/PNPTimeoutHandler.java
@@ -1,0 +1,163 @@
+/*
+ * ################################################################
+ *
+ * ProActive Parallel Suite(TM): The Java(TM) library for
+ *    Parallel, Distributed, Multi-Core Computing for
+ *    Enterprise Grids & Clouds
+ *
+ * Copyright (C) 1997-2016 INRIA/University of
+ *                 Nice-Sophia Antipolis/ActiveEon
+ * Contact: proactive@ow2.org or contact@activeeon.com
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation; version 3 of
+ * the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307
+ * USA
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ *
+ *  Initial developer(s):               The ActiveEon Team
+ *                        http://www.activeeon.com/
+ *  Contributor(s):
+ *
+ * ################################################################
+ * $$ACTIVEEON_INITIAL_DEV$$
+ */
+package org.objectweb.proactive.extensions.pnp;
+
+import org.apache.commons.collections4.queue.CircularFifoQueue;
+
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+/**
+ * Dynamic heartbeat timeout mechanism
+ */
+public class PNPTimeoutHandler {
+
+    private final long defaultHearbeatPeriod;
+
+    private final int heartbeatFactor;
+
+    private final CircularFifoQueue<Long> lastRecordedHeartBeatIntervals;
+
+    private long lastHeartBeat = 0;
+    private long lastInterval = 0;
+
+    private boolean heartbeatReceived = false;
+
+    private final ReentrantReadWriteLock rwLock = new ReentrantReadWriteLock();
+    private final ReentrantReadWriteLock.ReadLock readLock = rwLock.readLock();
+    private final ReentrantReadWriteLock.WriteLock writeLock = rwLock.writeLock();
+
+    public PNPTimeoutHandler(long defaultHearbeatPeriod, int heartbeatFactor, int heartbeatWindow) {
+        this.defaultHearbeatPeriod = defaultHearbeatPeriod;
+        this.heartbeatFactor = heartbeatFactor;
+        this.lastRecordedHeartBeatIntervals = new CircularFifoQueue<>(heartbeatWindow);
+    }
+
+    /**
+     * Returns the computed timeout based on last received heartbeats intervals
+     *
+     * @return
+     */
+    public long getTimeout() {
+        readLock.lock();
+        try {
+            if (defaultHearbeatPeriod == 0 || lastInterval == 0)
+                return heartbeatFactor * defaultHearbeatPeriod;
+            else {
+                long averageInterval = computeAverageInterval();
+                if (lastInterval > averageInterval)
+                    return heartbeatFactor * Math.max(defaultHearbeatPeriod, lastInterval);
+                else
+                    return heartbeatFactor * Math.max(defaultHearbeatPeriod, averageInterval);
+            }
+        } finally {
+            readLock.unlock();
+        }
+    }
+
+    private long computeAverageInterval() {
+        long sum = 0;
+        for (long interval : lastRecordedHeartBeatIntervals) {
+            sum += interval;
+        }
+        return Math.round(sum / lastRecordedHeartBeatIntervals.size());
+    }
+
+    public void resetNotification() {
+        writeLock.lock();
+        try {
+            heartbeatReceived = false;
+        } finally {
+            writeLock.unlock();
+        }
+    }
+
+    public HeartBeatNotificationData getNotificationData() {
+        readLock.lock();
+        try {
+            return new HeartBeatNotificationData(heartbeatReceived, lastInterval, getTimeout());
+        } finally {
+            readLock.unlock();
+        }
+    }
+
+    /**
+     * Registers a heartbeat arrival
+     *
+     * @param time system time when the heartbeat was received
+     */
+    public void recordHeartBeat(long time) {
+        writeLock.lock();
+        try {
+            heartbeatReceived = true;
+            if (lastHeartBeat == 0) {
+                lastHeartBeat = time;
+                return;
+            }
+            lastInterval = time - lastHeartBeat;
+            lastRecordedHeartBeatIntervals.add(lastInterval);
+            lastHeartBeat = time;
+
+        } finally {
+            writeLock.unlock();
+        }
+    }
+
+    public static class HeartBeatNotificationData {
+
+        private boolean heartBeatReceived;
+        private long lastHeartbeatInterval;
+        private long newTimeout;
+
+        public boolean heartBeatReceived() {
+            return heartBeatReceived;
+        }
+
+        public long getLastHeartBeatInterval() {
+            return lastHeartbeatInterval;
+        }
+
+        public long getTimeout() {
+            return newTimeout;
+        }
+
+        public HeartBeatNotificationData(boolean heartBeatReceived, long lastHeartbeatInterval, long newTimeout) {
+            this.heartBeatReceived = heartBeatReceived;
+            this.lastHeartbeatInterval = lastHeartbeatInterval;
+            this.newTimeout = newTimeout;
+        }
+    }
+}

--- a/programming-extensions/programming-extension-pnp/src/test/java/org/objectweb/proactive/extensions/pnp/PNPTimeoutHandlerTest.java
+++ b/programming-extensions/programming-extension-pnp/src/test/java/org/objectweb/proactive/extensions/pnp/PNPTimeoutHandlerTest.java
@@ -1,0 +1,155 @@
+/*
+ *  *
+ * ProActive Parallel Suite(TM): The Java(TM) library for
+ *    Parallel, Distributed, Multi-Core Computing for
+ *    Enterprise Grids & Clouds
+ *
+ * Copyright (C) 1997-2016 INRIA/University of
+ *                 Nice-Sophia Antipolis/ActiveEon
+ * Contact: proactive@ow2.org or contact@activeeon.com
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation; version 3 of
+ * the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307
+ * USA
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ *
+ *  Initial developer(s):               The ProActive Team
+ *                        http://proactive.inria.fr/team_members.htm
+ *  Contributor(s):
+ *
+ *  * $$ACTIVEEON_INITIAL_DEV$$
+ */
+package org.objectweb.proactive.extensions.pnp;
+
+import com.google.common.collect.Lists;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.List;
+
+public class PNPTimeoutHandlerTest {
+
+    private void recordHeartBeats(PNPTimeoutHandler handler, List<Integer> beats) {
+        for (long beat : beats) {
+            handler.recordHeartBeat(beat);
+        }
+    }
+
+    @Test
+    public void testHeartBeatReceived() {
+        PNPTimeoutHandler handler = new PNPTimeoutHandler(10, 2, 2);
+
+        recordHeartBeats(handler, Lists.newArrayList(1));
+        Assert.assertTrue("heartbeat was received", handler.getNotificationData().heartBeatReceived());
+
+        handler.resetNotification();
+        Assert.assertFalse("handler was reset and heartbeat was not received", handler.getNotificationData().heartBeatReceived());
+
+        Assert.assertEquals("last interval should not be set", 0, handler.getNotificationData().getLastHeartBeatInterval());
+        Assert.assertEquals("Timeout should be the default", 10 * 2, handler.getNotificationData().getTimeout());
+
+        recordHeartBeats(handler, Lists.newArrayList(1 + 12));
+        Assert.assertTrue("heartbeat was received", handler.getNotificationData().heartBeatReceived());
+        Assert.assertEquals("last interval should be set", 12, handler.getNotificationData().getLastHeartBeatInterval());
+        Assert.assertEquals("Timeout should be set accordingly", 12 * 2, handler.getNotificationData().getTimeout());
+    }
+
+
+    @Test
+    public void testDefaultZero() {
+        PNPTimeoutHandler handler = new PNPTimeoutHandler(0, 2, 2);
+
+        recordHeartBeats(handler, Lists.newArrayList(
+                1,
+                1 + 10,
+                1 + 10 + 12,
+                1 + 10 + 12 + 14,
+                1 + 10 + 12 + 14 + 16));
+        Assert.assertEquals("If default heartbeat period is 0, the timeout should be zero", 0, handler.getTimeout());
+
+    }
+
+
+    @Test
+    public void testNoData() {
+        PNPTimeoutHandler handler = new PNPTimeoutHandler(10, 2, 2);
+
+        recordHeartBeats(handler, Lists.newArrayList(1));
+        Assert.assertEquals("If not enough data to compute an interval, default should be used", 10 * 2, handler.getTimeout());
+
+    }
+
+
+    @Test
+    public void testGrowing() {
+        PNPTimeoutHandler handler = new PNPTimeoutHandler(10, 2, 2);
+
+        recordHeartBeats(handler, Lists.newArrayList(
+                1,
+                1 + 10,
+                1 + 10 + 12,
+                1 + 10 + 12 + 14,
+                1 + 10 + 12 + 14 + 16));
+        Assert.assertEquals("After growing beat delay, timeout should grow to the last beat interval", 16 * 2, handler.getTimeout());
+
+    }
+
+    @Test
+    public void testGrowingDecreasing() {
+        PNPTimeoutHandler handler = new PNPTimeoutHandler(10, 2, 2);
+
+        recordHeartBeats(handler, Lists.newArrayList(
+                1,
+                1 + 10,
+                1 + 10 + 12,
+                1 + 10 + 12 + 14,
+                1 + 10 + 12 + 14 + 16,
+                1 + 10 + 12 + 14 + 16 + 10,
+                1 + 10 + 12 + 14 + 16 + 10 + 10));
+        Assert.assertEquals("After growing beat delay and then normal period, timeout should grow then shrink to the average", 10 * 2, handler.getTimeout());
+
+    }
+
+
+    @Test
+    public void testUpsAndDowns1() {
+        PNPTimeoutHandler handler = new PNPTimeoutHandler(10, 2, 2);
+
+        recordHeartBeats(handler, Lists.newArrayList(
+                1,
+                1 + 10,
+                1 + 10 + 20,
+                1 + 10 + 20 + 10,
+                1 + 10 + 20 + 10 + 20));
+        Assert.assertEquals("When beat interval is oscillating between two values, if last value is bigger than average, then it should be used", 20 * 2, handler.getTimeout());
+
+    }
+
+    @Test
+    public void testUpsAndDowns2() {
+        PNPTimeoutHandler handler = new PNPTimeoutHandler(10, 2, 2);
+
+        recordHeartBeats(handler, Lists.newArrayList(
+                1,
+                1 + 10,
+                1 + 10 + 20,
+                1 + 10 + 20 + 10,
+                1 + 10 + 20 + 10 + 20,
+                1 + 10 + 20 + 10 + 20 + 10));
+        Assert.assertEquals("When beat interval is oscillating between two values, if last value is lower than average, then the average should be used", 15 * 2, handler.getTimeout());
+
+    }
+}

--- a/programming-extensions/programming-extension-pnpssl/src/main/java/org/objectweb/proactive/extensions/pnpssl/PNPSslConfig.java
+++ b/programming-extensions/programming-extension-pnpssl/src/main/java/org/objectweb/proactive/extensions/pnpssl/PNPSslConfig.java
@@ -73,7 +73,32 @@ final public class PNPSslConfig implements PAPropertiesLoaderSPI {
      * lower than 500 milliseconds.
      */
     static final public PAPropertyInteger PA_PNPSSL_DEFAULT_HEARTBEAT = new PAPropertyInteger(
-        "proactive.pnps.default_heartbeat", false, 9000);
+            "proactive.pnps.default_heartbeat", false, 10 * 1000);
+
+    /**
+     * A factor of the heartbeat period used to detect failure.
+     * The timeout used to detect a failure is set by default to heartbeat_period * factor.
+     * <p>
+     * This timeout is dynamically updated when receiving heartbeats to match the actual network delay observed.
+     * It can never be decreased below the default value: heartbeat_period * factor.
+     * <p>
+     * When the delay between heartbeats increases due to network delay or machine load, then the corresponding timeout will also increase.
+     * Technically, the last heartbeat interval is compared to proactive.pnp.heartbeat_window samples.
+     * If the last interval is bigger than the average, then the timeout will be set to: last_interval * factor,
+     * Otherwise, the timeout will be set to: average * factor
+     * <p>
+     * Thus, the heartbeat_factor property controls the tolerance of the mechanism regarding delay increase.
+     * If the factor is set too low, it can imply that a slight delay will be acknowledged as a network failure.
+     * If the factor is set too high, network failure detection will take a very long time.
+     * <p>
+     * The heartbeat_window property controls the "inertia" at which the timeout will be decreased back to its default value, after a period of increasing delay.
+     * If the heartbeat_window is set too low, then only a few samples will be considered and the timeout will always be set according to the last heartbeat interval.
+     * If the heartbeat_window is set too high, after a long period of network delay increase, the timeout will require the same amount of time to decrease back to its default value.
+     */
+    static final public PAPropertyInteger PA_PNPSSL_HEARTBEAT_FACTOR = new PAPropertyInteger(
+            "proactive.pnps.heartbeat_factor", false, 3);
+    static final public PAPropertyInteger PA_PNPSSL_HEARTBEAT_WINDOW = new PAPropertyInteger(
+            "proactive.pnps.heartbeat_window", false, 5);
 
     /**
      * Channel garbage collection timeout (in milliseconds)

--- a/programming-extensions/programming-extension-pnpssl/src/main/java/org/objectweb/proactive/extensions/pnpssl/PNPSslRemoteObjectFactory.java
+++ b/programming-extensions/programming-extension-pnpssl/src/main/java/org/objectweb/proactive/extensions/pnpssl/PNPSslRemoteObjectFactory.java
@@ -36,6 +36,20 @@
  */
 package org.objectweb.proactive.extensions.pnpssl;
 
+import org.apache.log4j.Logger;
+import org.objectweb.proactive.core.util.log.ProActiveLogger;
+import org.objectweb.proactive.extensions.pnp.PNPConfig;
+import org.objectweb.proactive.extensions.pnp.PNPExtraHandlers;
+import org.objectweb.proactive.extensions.pnp.PNPRemoteObjectFactoryAbstract;
+import org.objectweb.proactive.extensions.pnp.PNPRemoteObjectFactoryBackend;
+import org.objectweb.proactive.extensions.ssl.CertificateGenerator;
+import org.objectweb.proactive.extensions.ssl.PermissiveTrustManager;
+import org.objectweb.proactive.extensions.ssl.SameCertTrustManager;
+import org.objectweb.proactive.extensions.ssl.SecureMode;
+import org.objectweb.proactive.extensions.ssl.SslException;
+import org.objectweb.proactive.extensions.ssl.SslHelpers;
+
+import javax.net.ssl.TrustManager;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -50,22 +64,6 @@ import java.security.cert.X509Certificate;
 import java.util.Enumeration;
 import java.util.LinkedList;
 import java.util.List;
-
-import javax.net.ssl.TrustManager;
-
-import org.apache.log4j.Logger;
-import org.objectweb.proactive.core.config.CentralPAPropertyRepository;
-import org.objectweb.proactive.core.util.log.ProActiveLogger;
-import org.objectweb.proactive.extensions.pnp.PNPRemoteObjectFactoryAbstract;
-import org.objectweb.proactive.extensions.pnp.PNPConfig;
-import org.objectweb.proactive.extensions.pnp.PNPExtraHandlers;
-import org.objectweb.proactive.extensions.pnp.PNPRemoteObjectFactoryBackend;
-import org.objectweb.proactive.extensions.ssl.CertificateGenerator;
-import org.objectweb.proactive.extensions.ssl.PermissiveTrustManager;
-import org.objectweb.proactive.extensions.ssl.SslHelpers;
-import org.objectweb.proactive.extensions.ssl.SameCertTrustManager;
-import org.objectweb.proactive.extensions.ssl.SecureMode;
-import org.objectweb.proactive.extensions.ssl.SslException;
 
 
 /**
@@ -86,6 +84,8 @@ public class PNPSslRemoteObjectFactory extends PNPRemoteObjectFactoryAbstract {
         config.setPort(PNPSslConfig.PA_PNPSSL_PORT.getValue());
         config.setIdleTimeout(PNPSslConfig.PA_PNPSSL_IDLE_TIMEOUT.getValue());
         config.setDefaultHeartbeat(PNPSslConfig.PA_PNPSSL_DEFAULT_HEARTBEAT.getValue());
+        config.setHeartbeatFactor(PNPSslConfig.PA_PNPSSL_HEARTBEAT_FACTOR.getValue());
+        config.setHeartbeatWindow(PNPSslConfig.PA_PNPSSL_HEARTBEAT_WINDOW.getValue());
 
         if (PNPSslConfig.PA_PNPSSL_AUTHENTICATE.isTrue() && !PNPSslConfig.PA_PNPSSL_KEYSTORE.isSet()) {
             throw new PNPSslConfigurationException(PNPSslConfig.PA_PNPSSL_KEYSTORE.getName() +

--- a/programming-test/src/test/java/functionalTests/pnp/TestPNPTimeout.java
+++ b/programming-test/src/test/java/functionalTests/pnp/TestPNPTimeout.java
@@ -1,0 +1,212 @@
+/*
+ * ################################################################
+ *
+ * ProActive Parallel Suite(TM): The Java(TM) library for
+ *    Parallel, Distributed, Multi-Core Computing for
+ *    Enterprise Grids & Clouds
+ *
+ * Copyright (C) 1997-2016 INRIA/University of
+ *                 Nice-Sophia Antipolis/ActiveEon
+ * Contact: proactive@ow2.org or contact@activeeon.com
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation; version 3 of
+ * the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307
+ * USA
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ *
+ *  Initial developer(s):               The ProActive Team
+ *                        http://proactive.inria.fr/team_members.htm
+ *  Contributor(s):
+ *
+ * ################################################################
+ * $$PROACTIVE_INITIAL_DEV$$
+ */
+package functionalTests.pnp;
+
+import functionalTests.FunctionalTest;
+import functionalTests.GCMFunctionalTest;
+import org.apache.log4j.Level;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.objectweb.proactive.ActiveObjectCreationException;
+import org.objectweb.proactive.api.PAActiveObject;
+import org.objectweb.proactive.api.PAFuture;
+import org.objectweb.proactive.core.ProActiveException;
+import org.objectweb.proactive.core.config.CentralPAPropertyRepository;
+import org.objectweb.proactive.core.node.Node;
+import org.objectweb.proactive.core.node.NodeException;
+import org.objectweb.proactive.core.remoteobject.RemoteObjectSet.NotYetExposedException;
+import org.objectweb.proactive.core.remoteobject.exception.UnknownProtocolException;
+import org.objectweb.proactive.core.util.log.ProActiveLogger;
+import org.objectweb.proactive.core.util.wrapper.BooleanWrapper;
+import org.objectweb.proactive.extensions.annotation.ActiveObject;
+import org.objectweb.proactive.extensions.pnp.PNPConfig;
+
+
+public class TestPNPTimeout extends GCMFunctionalTest {
+
+    static final int TEST_HEART_BEAT = 1000;
+
+    static final int TEST_FACTOR = 3;
+
+    static final long WAIT_TIME = 60000;
+
+
+    @BeforeClass
+    static public void prepareForTest() throws Exception {
+        CentralPAPropertyRepository.PA_COMMUNICATION_PROTOCOL.setValue("pnp");
+        PNPConfig.PA_PNP_DEFAULT_HEARTBEAT.setValue(TEST_HEART_BEAT);
+        PNPConfig.PA_PNP_HEARTBEAT_FACTOR.setValue(TEST_FACTOR);
+        ProActiveLogger.getLogger(PNPConfig.Loggers.PNP).setLevel(Level.TRACE);
+        FunctionalTest.prepareForTest();
+    }
+
+    public TestPNPTimeout() throws ProActiveException {
+        super(1, 1);
+
+        super.setOptionalJvmParamters(
+                PNPConfig.PA_PNP_DEFAULT_HEARTBEAT.getCmdLine() + TEST_HEART_BEAT + " " +
+                        PNPConfig.PA_PNP_HEARTBEAT_FACTOR.getCmdLine() + TEST_FACTOR);
+        super.startDeployment();
+    }
+
+    /**
+     * This test ensures that:
+     * - no timeout exception is raised when adding a progressively growing delay to an active object pnp server (heartbeat timeouts raise proportionally)
+     * - no timeout exception is raised with the same delay on a second active object server on the same proactive node
+     * - after removing this delay, a serie of method calls work and it can be observed in the logs that the pnp heartbeat timeouts have decreased.
+     * (this last bit can be observed in the log, but it seems not possible to check this via assertions).
+     */
+    @Test(timeout = 300000)
+    public void testGrowingDelay() throws ActiveObjectCreationException, NodeException, UnknownProtocolException,
+            NotYetExposedException, InterruptedException {
+
+        System.out.println("Starting test: growing delay");
+        Node node = super.getANode();
+
+        GrowingDelayAO remote = PAActiveObject.newActive(GrowingDelayAO.class, new Object[0], node);
+
+        System.out.println("Start growing delay");
+        // call to this method will generate a growing delay on the server
+        BooleanWrapper future = remote.growingDelay();
+
+        try {
+            Assert.assertTrue(PAFuture.getFutureValue(future).getBooleanValue());
+        } catch (Exception e) {
+            e.printStackTrace();
+            Assert.fail("After these growing delays were created, no timeout exception should be raised when receiving the method result.");
+        }
+
+        // the server delay should be maximum
+        GrowingDelayAO remote2 = PAActiveObject.newActive(GrowingDelayAO.class, new Object[0], node);
+
+        Assert.assertTrue("Call to the second active object, with a big delay should not raise exceptions", remote2.simpleMessage());
+
+        remote.removeDelay();
+        // the server delay is now set to 0
+        System.out.println("End growing delay");
+
+        for (int i = 0; i < 20; i++) {
+            Thread.sleep(1000);
+            Assert.assertTrue("Subsequent calls on the first active object with delay reset should not raise exceptions", remote.simpleMessage());
+            Assert.assertTrue("Subsequent calls on the second active object with delay reset should not raise exceptions", remote2.simpleMessage());
+        }
+        System.out.println("End test: growing delay");
+    }
+
+    @After
+    public void releaseNodes() throws Throwable {
+        killDeployment();
+    }
+
+
+    /**
+     * This test ensures that a timeout exception is raised when a big delay is suddenly added to an active object's pnp server.
+     */
+    @Test(timeout = 120000)
+    public void testBigDelay() throws ActiveObjectCreationException, NodeException, UnknownProtocolException,
+            NotYetExposedException, InterruptedException {
+        System.out.println("Starting test: big delay");
+        Node node = super.getANode();
+
+        GrowingDelayAO remote = PAActiveObject.newActive(GrowingDelayAO.class, new Object[0], node);
+
+        BooleanWrapper future = remote.addBigDelay();
+
+        try {
+            PAFuture.getFutureValue(future).getBooleanValue();
+            Assert.fail("Due to the big delay, an expection should have been raised.");
+        } catch (Exception e) {
+            System.out.println("The following exception is expected:");
+            e.printStackTrace(System.out);
+        }
+        System.out.println("End test: big delay");
+    }
+
+    private static void simulateServerGrowingDelay() {
+
+        long beginTime = System.currentTimeMillis();
+        int startperiod = TEST_HEART_BEAT;
+        try {
+            int i = 0;
+            while (System.currentTimeMillis() - beginTime < WAIT_TIME) {
+                PNPConfig.PA_PNP_TEST_RANDOMDELAY.setValue(startperiod / 4 * i);
+                Thread.sleep(startperiod / 4 * i * TEST_FACTOR);
+                i++;
+            }
+        } catch (InterruptedException e) {
+            logger.error("", e);
+        }
+    }
+
+    @ActiveObject
+    public static class GrowingDelayAO {
+
+        public GrowingDelayAO() {
+            // Do nothing
+        }
+
+        public boolean simpleMessage() {
+            return true;
+        }
+
+        public boolean removeDelay() {
+            PNPConfig.PA_PNP_TEST_RANDOMDELAY.setValue(0);
+            logger.info("Removed delay");
+            return true;
+        }
+
+        public BooleanWrapper addBigDelay() {
+            PNPConfig.PA_PNP_TEST_RANDOMDELAY.setValue(30000);
+            logger.info("Added big delay");
+            try {
+                Thread.sleep(WAIT_TIME);
+            } catch (InterruptedException e) {
+                logger.info("", e);
+            }
+            return new BooleanWrapper(true);
+        }
+
+        public BooleanWrapper growingDelay() {
+            logger.info("Start growing delay");
+            simulateServerGrowingDelay();
+            logger.info("Maximum delay");
+            return new BooleanWrapper(true);
+        }
+    }
+}

--- a/programming-test/src/test/resources/functionalTests/_CONFIG/JunitApp.xml
+++ b/programming-test/src/test/resources/functionalTests/_CONFIG/JunitApp.xml
@@ -28,8 +28,8 @@
 					<pathElement base="proactive" relpath="programming-test/build/resources/test/"/>
 					<pathElement base="proactive" relpath="programming-test/build/dist/lib/*"/>
 					<pathElement base="proactive" relpath="dist/lib/clover.jar"/>
-				</proactiveClasspath>	
-<!--				<log4jProperties base="proactive" relpath="compile/proactive-log4j"/> -->
+				</proactiveClasspath>
+				<log4jProperties base="proactive" relpath="compile/proactive-log4j"/>
 		      <!--   <proactiveSecurity>
 		          <applicationPolicy base="proactive" relpath="descriptors/security/applicationPolicy1.xml"/>
 		          <runtimePolicy base="proactive" relpath="descriptors/security/applicationPolicy1.xml"/>


### PR DESCRIPTION
This change includes the following
  - Added proactive.pnp.heartbeat_factor and proactive.pnp.heartbeat_window properties to control the algorithm
  - Added the class PNPTimeoutHandler to return the dynamically computed timeout
  - Removed the deadline update when a standard message was received as it was conficting with the algorithm
  - Added a unit test for the PNPTimeoutHandler class
  - Added a functional test to check that timeout is correctly handled when executing two different scenarios
   - Added the proactive.pnp.test.random_delay to simulate a pnp server delay, needed by the functional test