### PR TITLE
Add support to environment modification in LinuxProcessBuilder

### DIFF
--- a/programming-extensions/programming-extension-processbuilder/src/main/resources/processbuilder/linux/launch.sh
+++ b/programming-extensions/programming-extension-processbuilder/src/main/resources/processbuilder/linux/launch.sh
@@ -47,7 +47,16 @@ tmp=`mktemp  2>/dev/null || mktemp  -t 'mytmpfile'`
 
 if [ "$?" != "0" ]; then
   # if I can not create a tempfile
-  echo "$OSPL_E_PREFIX ${OSLP_PACKAGE}FatalProcessBuilderException $OSPL_E_CAUSE Could not create temp file for storing the return value!" 1>&2; 
+  echo "$OSPL_E_PREFIX ${OSLP_PACKAGE}FatalProcessBuilderException $OSPL_E_CAUSE Could not create temp file for storing the return value!" 1>&2;
+  exit 1;
+fi;
+
+# create temp file for environment variables
+tmpenv=`mktemp  2>/dev/null || mktemp  -t 'myenvfile'`
+
+if [ "$?" != "0" ]; then
+  # if I can not create a tempfile
+  echo "$OSPL_E_PREFIX ${OSLP_PACKAGE}FatalProcessBuilderException $OSPL_E_CAUSE Could not create temp file for storing the environment variable!" 1>&2;
   exit 1;
 fi;
 
@@ -55,6 +64,7 @@ fi;
 # TODO: grant only to the user we are going to change into?
 # grant permission for r/w
 chmod 666 $tmp
+chmod 666 $tmpenv
 
 # first jump - core binding
 # ATTENTION: not implemented ;) TODO
@@ -62,30 +72,33 @@ if [ "$crs" != "" ]; then
   error="$OSPL_E_PREFIX ${OSLP_PACKAGE}CoreBindingException $OSPL_E_CAUSE Core binding is not supported!"
   echo $error 1>&2
   rm $tmp;
+  rm $tmpenv 2> /dev/null
   exit 1;
 else 
   # If the username is not empty we proceed with the user_step
   if [ "$usr" != "" ]; then
     # we get rid of the first 5 parameters
     shift;shift;shift;shift;shift
-    ./user_step.sh $token $tmp "$workdir" "$usr" "$@"
+    ./user_step.sh $token $tmp $tmpenv "$workdir" "$usr" "$@"
     if [ "$?" != "0" ]; then
     # return value of the user_step is not 0 only in case the sudo failed, otherwise it is 0
     error="$OSPL_E_PREFIX ${OSLP_PACKAGE}FatalProcessBuilderException $OSPL_E_CAUSE User change script could not execute!"
     echo $error 1>&2
-    rm $tmp;
+    rm $tmp 2> /dev/null
+    rm $tmpenv 2> /dev/null
     exit 1;
     fi;
     
   else
   # If the username is empty, we just execute the command...
   # It is worth mentioning that in case neither the username nor the cores are set, one should just use Runtime.exec, and not these scripts.
-    ./command_step.sh $tmp "$workdir" "$@";
+    ./command_step.sh $tmp $tmpenv "$workdir" "$@";
     if [ "$?" != "0" ]; then
     # return value of the user_step is not 0 only in case the sudo failed, otherwise it is 0
     error="$OSPL_E_PREFIX ${OSLP_PACKAGE}FatalProcessBuilderException $OSPL_E_CAUSE Command executor script could not execute!"
     echo $error 1>&2
-    rm $tmp;
+    rm $tmp 2> /dev/null
+    rm $tmpenv 2> /dev/null
     exit 1;
     fi;
   fi;
@@ -94,6 +107,7 @@ else
   
   exitv=`cat < $tmp` 2> /dev/null
   # maybe check if it exists etc. - may come in handy if we don't break on the first error coming from the scripts
-  rm $tmp; 2> /dev/null
+  rm $tmp 2> /dev/null
+  rm $tmpenv 2> /dev/null
   exit $exitv;
 fi;

--- a/programming-extensions/programming-extension-processbuilder/src/test/java/org/objectweb/proactive/extensions/processbuilder/LinuxProcessBuilderTest.java
+++ b/programming-extensions/programming-extension-processbuilder/src/test/java/org/objectweb/proactive/extensions/processbuilder/LinuxProcessBuilderTest.java
@@ -1,21 +1,35 @@
 package org.objectweb.proactive.extensions.processbuilder;
 
-import java.io.File;
-
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
+import org.apache.log4j.BasicConfigurator;
+import org.apache.log4j.Level;
+import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
+import org.objectweb.proactive.core.util.log.Loggers;
+import org.objectweb.proactive.core.util.log.ProActiveLogger;
 
-import static org.junit.Assert.*;
+import java.io.File;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 @Ignore("Ignored because it depends too much on the environment, but can be used for manual testing")
 public class LinuxProcessBuilderTest {
 
     private static final String USERNAME = "user";
     private static final String PASSWORD = "pwd";
-    private static final String PROACTIVE_HOME = "/Users/user/src/programming";
-    private static final String PATH_TO_SSH_PRIVATE_KEY = "/Users/" + USERNAME + "/.ssh/id_rsa";
+    private static final String PROACTIVE_HOME = "/tmp/programming";
+    private static final String PATH_TO_SSH_PRIVATE_KEY = "/tmp/.ssh/id_rsa";
+
+
+    @Before
+    public void before() {
+        BasicConfigurator.resetConfiguration();
+        BasicConfigurator.configure();
+        ProActiveLogger.getLogger(Loggers.OSPB).setLevel(Level.DEBUG);
+    }
 
     @Test
     public void sudo() throws Exception {
@@ -29,6 +43,22 @@ public class LinuxProcessBuilderTest {
     }
 
     @Test
+    public void sudoEnvVar() throws Exception {
+        LinuxProcessBuilder processBuilder = new LinuxProcessBuilder(new OSUser(USERNAME), null,
+                PROACTIVE_HOME);
+
+        processBuilder.environment().put("MYVAR1", "MYVALUE1");
+        processBuilder.environment().put("MYVAR2", "MYVALUE2");
+        Process process = processBuilder.command("env").start();
+        int exitCode = process.waitFor();
+        assertEquals(0, exitCode);
+        String output = IOUtils.toString(process.getInputStream());
+        System.out.println(output);
+        assertTrue(output.contains("MYVALUE1"));
+        assertTrue(output.contains("MYVALUE2"));
+    }
+
+    @Test
     public void su() throws Exception {
         LinuxProcessBuilder processBuilder = new LinuxProcessBuilder(new OSUser(USERNAME, PASSWORD), null,
             PROACTIVE_HOME);
@@ -39,11 +69,26 @@ public class LinuxProcessBuilderTest {
         assertEquals(0, exitCode);
     }
 
+    @Test
+    public void suEnvVar() throws Exception {
+        LinuxProcessBuilder processBuilder = new LinuxProcessBuilder(new OSUser(USERNAME, PASSWORD), null,
+                PROACTIVE_HOME);
+
+        processBuilder.environment().put("MYVAR1", "MYVALUE1");
+        processBuilder.environment().put("MYVAR2", "MYVALUE2");
+        Process process = processBuilder.command("env").start();
+        int exitCode = process.waitFor();
+        assertEquals(0, exitCode);
+        String output = IOUtils.toString(process.getInputStream());
+        System.out.println(output);
+        assertTrue(output.contains("MYVALUE1"));
+        assertTrue(output.contains("MYVALUE2"));
+    }
+
     @Test(timeout = 5000)
     public void su_destroy_process() throws Exception {
         LinuxProcessBuilder processBuilder = new LinuxProcessBuilder(new OSUser(USERNAME, PASSWORD), null,
             PROACTIVE_HOME);
-
         Process process = processBuilder.command("sleep", "5").start();
         process.destroy();
         int exitCode = process.waitFor();
@@ -60,5 +105,20 @@ public class LinuxProcessBuilderTest {
         int exitCode = process.waitFor();
 
         assertEquals(0, exitCode);
+    }
+
+    @Test
+    public void sshEnvVar() throws Exception {
+        LinuxProcessBuilder processBuilder = new LinuxProcessBuilder(new OSUser(USERNAME,
+                FileUtils.readFileToByteArray(new File(PATH_TO_SSH_PRIVATE_KEY))), null, PROACTIVE_HOME);
+        processBuilder.environment().put("MYVAR1", "MYVALUE1");
+        processBuilder.environment().put("MYVAR2", "MYVALUE2");
+        Process process = processBuilder.command("env").start();
+        int exitCode = process.waitFor();
+        assertEquals(0, exitCode);
+        String output = IOUtils.toString(process.getInputStream());
+        System.out.println(output);
+        assertTrue(output.contains("MYVALUE1"));
+        assertTrue(output.contains("MYVALUE2"));
     }
 }


### PR DESCRIPTION
- environment modification is implemented by creating a temporary file which stores custom variables provided by the user
- this file is sourced in the command_step.sh, i.e after the impersonation
- added tests which ensure that variables are correctly set the user environment

Tested succesfully for all 3 implementations (sudo, su, ssh).