### PR TITLE
Improve tests for processbuilder extensions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -141,7 +141,7 @@ project(':programming-build-utils') {
         compile 'ant:ant:1.7.0'
         compile 'commons-cli:commons-cli:1.3.1'
         compile "log4j:log4j:1.2.17"
-        compile 'org.jvnet.winp:winp:1.23-proactive'
+        compile 'org.jvnet.winp:winp:1.24'
     }
 }
 
@@ -351,6 +351,20 @@ project('programming-extensions:programming-extension-processbuilder') {
             }
             suer.dependsOn suermac64
         }
+    }
+
+    test {
+        if (project.hasProperty('runasme.user')) {
+            systemProperties << ['runasme.user': project.property('runasme.user')]
+        }
+        if (project.hasProperty('runasme.pwd')) {
+            systemProperties << ['runasme.pwd': project.property('runasme.pwd')]
+        }
+        if (project.hasProperty('runasme.key.path')) {
+            systemProperties << ['runasme.key.path': project.property('runasme.key.path')]
+        }
+
+        systemProperties << ['proactive.home': rootDir.absolutePath]
     }
 }
 

--- a/programming-extensions/programming-extension-processbuilder/src/test/java/org/objectweb/proactive/extensions/processbuilder/ProcessBuilderTest.java
+++ b/programming-extensions/programming-extension-processbuilder/src/test/java/org/objectweb/proactive/extensions/processbuilder/ProcessBuilderTest.java
@@ -1,0 +1,20 @@
+package org.objectweb.proactive.extensions.processbuilder;
+
+import org.junit.BeforeClass;
+
+import static org.junit.Assume.assumeTrue;
+
+public class ProcessBuilderTest {
+    public static final String PROCESSBUILDER_USERNAME_PROPNAME = "runasme.user";
+    public static final String PROCESSBUILDER_PASSWORD_PROPNAME = "runasme.pwd";
+    protected static String username;
+    protected static String password;
+
+    @BeforeClass
+    public static void beforeClass() {
+        username = System.getProperty(PROCESSBUILDER_USERNAME_PROPNAME);
+        assumeTrue(username != null);
+        password = System.getProperty(PROCESSBUILDER_PASSWORD_PROPNAME);
+        assumeTrue(password != null);
+    }
+}

--- a/programming-extensions/programming-extension-processbuilder/src/test/java/org/objectweb/proactive/extensions/processbuilder/WindowsProcessBuilderTest.java
+++ b/programming-extensions/programming-extension-processbuilder/src/test/java/org/objectweb/proactive/extensions/processbuilder/WindowsProcessBuilderTest.java
@@ -1,37 +1,72 @@
 package org.objectweb.proactive.extensions.processbuilder;
 
-import org.apache.commons.io.FileUtils;
-import org.junit.Ignore;
+import org.apache.commons.io.IOUtils;
+import org.apache.log4j.BasicConfigurator;
+import org.apache.log4j.Level;
+import org.junit.Before;
 import org.junit.Test;
-
-import java.io.File;
+import org.objectweb.proactive.core.util.log.Loggers;
+import org.objectweb.proactive.core.util.log.ProActiveLogger;
+import org.objectweb.proactive.utils.OperatingSystem;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
 
 
-@Ignore("Ignored because it depends too much on the environment, but can be used for manual testing")
-public class WindowsProcessBuilderTest {
+public class WindowsProcessBuilderTest extends ProcessBuilderTest {
 
-    private static final String USERNAME = "user";
-    private static final String PASSWORD = "pwd";
+    @Before
+    public void before() {
+        assumeTrue(OperatingSystem.getOperatingSystem() == OperatingSystem.windows);
+
+        BasicConfigurator.resetConfiguration();
+        BasicConfigurator.configure();
+        ProActiveLogger.getLogger(Loggers.OSPB).setLevel(Level.DEBUG);
+    }
+
 
     @Test
     public void runas() throws Exception {
-        WindowsProcessBuilder processBuilder = new WindowsProcessBuilder(new OSUser(USERNAME, PASSWORD),
+        WindowsProcessBuilder processBuilder = new WindowsProcessBuilder(new OSUser(username, password),
                 null, null);
 
         Process process = processBuilder.command("hostname").start();
         int exitCode = process.waitFor();
+
+        System.out.println("[RUNAS] Process finished with exit code : " + exitCode);
 
         assertEquals(0, exitCode);
     }
 
     @Test(timeout = 7000)
     public void runas_destroy_process() throws Exception {
-        WindowsProcessBuilder processBuilder = new WindowsProcessBuilder(new OSUser(USERNAME, PASSWORD),
+        WindowsProcessBuilder processBuilder = new WindowsProcessBuilder(new OSUser(username, password),
                 null, null);
 
         Process process = processBuilder.command("ping", "-n", "20", "localhost").start();
         process.destroy();
+
+        System.out.println("[RUNAS_DESTROYPROCESS] Process finished with exit code : " + process.waitFor());
+    }
+
+    @Test
+    public void runasEnvVar() throws Exception {
+        WindowsProcessBuilder processBuilder = new WindowsProcessBuilder(new OSUser(username, password),
+                null, null);
+
+        processBuilder.environment().put("MYVAR1", "MYVALUE1");
+        processBuilder.environment().put("MYVAR2", "MYVALUE2");
+
+        Process process = processBuilder.command("cmd.exe", "/c", "set").start();
+        int exitCode = process.waitFor();
+        System.out.println("[RUNAS_ENVAR] Process finished with exit code : " + exitCode);
+
+        assertEquals(0, exitCode);
+
+        String output = IOUtils.toString(process.getInputStream());
+        System.out.println(output);
+        assertTrue(output.contains("MYVALUE1"));
+        assertTrue(output.contains("MYVALUE2"));
     }
 }


### PR DESCRIPTION
- allow the tests to be triggered if credential properties are defined in the gradle project
- added a test in WindowsProcessBuilderTest which check that the process environment can be modified