### PR TITLE
Add a cleanup timeout to the run as me Process implementation

### DIFF
--- a/programming-extensions/programming-extension-processbuilder/src/main/java/org/objectweb/proactive/extensions/processbuilder/CleanupTimeoutGetter.java
+++ b/programming-extensions/programming-extension-processbuilder/src/main/java/org/objectweb/proactive/extensions/processbuilder/CleanupTimeoutGetter.java
@@ -1,0 +1,82 @@
+/*
+ *  *
+ * ProActive Parallel Suite(TM): The Java(TM) library for
+ *    Parallel, Distributed, Multi-Core Computing for
+ *    Enterprise Grids & Clouds
+ *
+ * Copyright (C) 1997-2017 INRIA/University of
+ *                 Nice-Sophia Antipolis/ActiveEon
+ * Contact: proactive@ow2.org or contact@activeeon.com
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation; version 3 of
+ * the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307
+ * USA
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ *
+ *  Initial developer(s):               The ProActive Team
+ *                        http://proactive.inria.fr/team_members.htm
+ *  Contributor(s): ActiveEon Team - http://www.activeeon.com
+ *
+ *  * $$ACTIVEEON_CONTRIBUTOR$$
+ */
+package org.objectweb.proactive.extensions.processbuilder;
+
+import org.apache.log4j.Logger;
+
+
+public class CleanupTimeoutGetter {
+
+    private static final Logger LOGGER = Logger.getLogger(CleanupTimeoutGetter.class);
+    private static final String SECONDS_TASK_CLEANUP_TIMEOUT_PROP_NAME =
+            "proactive.process.builder.cleanup.time.seconds";
+
+    private static final long CLEANUP_TIME_DEFAULT_SECONDS = 10;
+
+    public long getCleanupTimeSeconds() {
+        try {
+            String cleanupTimeString = System.getProperty(SECONDS_TASK_CLEANUP_TIMEOUT_PROP_NAME);
+            writePropertyDebugMessageIfEnabled(cleanupTimeString);
+            if (cleanupTimeString != null) {
+                return Long.parseLong(cleanupTimeString);
+            } else {
+                writeDefaultPropertyUsedDebugMessageIfEnabled();
+                return CLEANUP_TIME_DEFAULT_SECONDS;
+            }
+        } catch (NumberFormatException e) {
+            LOGGER.warn("proactive.task.cleanup.time: "
+                    + System.getProperty(SECONDS_TASK_CLEANUP_TIMEOUT_PROP_NAME)
+                    + " is not parsable to long, fallback to default value. Error : "
+                    + e.getMessage());
+            return CLEANUP_TIME_DEFAULT_SECONDS;
+        }
+    }
+
+    private void writeDefaultPropertyUsedDebugMessageIfEnabled() {
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("Cleanup timeout default value used: " + CLEANUP_TIME_DEFAULT_SECONDS);
+        }
+    }
+
+    private void writePropertyDebugMessageIfEnabled(String cleanupTimeString) {
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("Cleanup timeout retrieved from property: " + cleanupTimeString);
+        }
+    }
+
+    public String getCleanupTimeSecondsString() {
+        return Long.toString(this.getCleanupTimeSeconds());
+    }
+}

--- a/programming-extensions/programming-extension-processbuilder/src/main/java/org/objectweb/proactive/extensions/processbuilder/LinuxProcessBuilder.java
+++ b/programming-extensions/programming-extension-processbuilder/src/main/java/org/objectweb/proactive/extensions/processbuilder/LinuxProcessBuilder.java
@@ -621,6 +621,8 @@ public class LinuxProcessBuilder implements OSProcessBuilder {
         final private OSUser user;
         final private String token;
 
+        private CleanupTimeoutGetter cleanupTimeoutGetter = new CleanupTimeoutGetter();
+
         public OSLinuxProcess(Process p, OSUser user, String token, String scriptBaseFolder) {
             this.process = p;
             this.scriptBaseFolder = scriptBaseFolder;
@@ -634,7 +636,8 @@ public class LinuxProcessBuilder implements OSProcessBuilder {
                 LinuxProcessBuilder lpb = new LinuxProcessBuilder(user, null, scriptBaseFolder);
                 String killProcessTreeScript = new File(scriptBaseFolder, PROCESS_TREE_KILLER_LOCATION)
                         .getAbsolutePath();
-                lpb.command(killProcessTreeScript, this.token);
+                lpb.directory(new File(System.getProperty("java.io.tmpdir")));
+                lpb.command(killProcessTreeScript, this.token, this.cleanupTimeoutGetter.getCleanupTimeSecondsString());
                 Process p = lpb.start();
                 p.waitFor();
 

--- a/programming-extensions/programming-extension-processbuilder/src/main/resources/processbuilder/linux/command_step.sh
+++ b/programming-extensions/programming-extension-processbuilder/src/main/resources/processbuilder/linux/command_step.sh
@@ -19,6 +19,8 @@ OSPL_E_CAUSE="CAUSE";
 OSLP_PACKAGE="org.objectweb.proactive.extensions.processbuilder.exception."
 #---------------
 
+trap "echo trapped signal" SIGTERM
+
 token=$1
 
 # temp file

--- a/programming-extensions/programming-extension-processbuilder/src/main/resources/processbuilder/linux/kill_process_tree.sh
+++ b/programming-extensions/programming-extension-processbuilder/src/main/resources/processbuilder/linux/kill_process_tree.sh
@@ -4,9 +4,42 @@
 # pattern. Any process which does not belong the current user will be ingored.
 
 LOGIN=$(whoami)
+
+parentPid=`ps -o ppid= -p $$`
+######## SEND SIGTERM
 for ppid in `pgrep -u $LOGIN -f $1`;
 do
-  if [ $ppid -ne $$ ]
+  if [ $ppid -ne $$ -a $ppid -ne $parentPid ]
+  then
+    for pid in `pstree -p $ppid | grep -o -E [0-9]+`
+    do
+      kill -15 $pid > /dev/null 2>&1
+    done
+  fi
+done
+
+
+
+###### WAIT FOR PROCESSES TO BE STOPPED
+# Iterate in seconds
+for iteration in $(seq 1 $2)
+do
+    if [ `pgrep -u $LOGIN -f $1 -c` -eq "2" ] # command_step.sh executes kill_process.tree.sh, so two processes
+    # means nothing else than the killing procedure is running
+    then
+        break # Processes don't exist -> so don't wait
+    fi
+    echo "Sleep a second: $iteration"
+    sleep 1s # Sleep one seconds, because timeout is expressed in seconds
+done
+
+
+
+
+##### SEND SIGKILL AFTER TIMEOUT HIT
+for ppid in `pgrep -u $LOGIN -f $1`;
+do
+  if [ $ppid -ne $$ -a $ppid -ne $parentPid ]
   then
     for pid in `pstree -p $ppid | grep -o -E [0-9]+`
     do

--- a/programming-extensions/programming-extension-processbuilder/src/test/java/org/objectweb/proactive/extensions/processbuilder/CleanupTimeoutGetterTest.java
+++ b/programming-extensions/programming-extension-processbuilder/src/test/java/org/objectweb/proactive/extensions/processbuilder/CleanupTimeoutGetterTest.java
@@ -1,0 +1,40 @@
+package org.objectweb.proactive.extensions.processbuilder;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+
+import org.junit.Test;
+
+public class CleanupTimeoutGetterTest {
+
+    private static final long CLEANUP_TIME_DEFAULT_SECONDS = 10;
+    private static final String CLEANUP_TIME_PROPERTY_NAME = "proactive.process.builder.cleanup.time.seconds";
+
+    @Test
+    public void testThatDefaultTimeoutIsReturnedIfNoPropertyIsSet() {
+        testThatReturnedTimeoutIs(CLEANUP_TIME_DEFAULT_SECONDS);
+    }
+
+    @Test
+    public void testThatDefaultTimeoutIsReturnedIfPropertyIsSetToGarbage() {
+        System.setProperty(CLEANUP_TIME_PROPERTY_NAME, "bahasd3342");
+        testThatReturnedTimeoutIs(CLEANUP_TIME_DEFAULT_SECONDS);
+        System.clearProperty(CLEANUP_TIME_PROPERTY_NAME);
+    }
+
+    @Test
+    public void testThatCorrectValueIsReturnedIfProperyIsSet() {
+        System.setProperty(CLEANUP_TIME_PROPERTY_NAME, "15");
+        testThatReturnedTimeoutIs(15L);
+        System.clearProperty(CLEANUP_TIME_PROPERTY_NAME);
+    }
+
+    private void testThatReturnedTimeoutIs(long expectedTimeout) {
+
+        CleanupTimeoutGetter cleanupTimeoutGetter =
+                new CleanupTimeoutGetter();
+        assertThat(cleanupTimeoutGetter.getCleanupTimeSeconds(), is(expectedTimeout));
+    }
+
+}


### PR DESCRIPTION
Add a cleanup timeout to the run as me Process implementation

Problem:
- Run as me Process implementation does SIGKILL whole process tree

Solution:
- Retrieve the cleanup timeout and pass it to the kill_process_tree.sh script
- kill_process_tree.sh SIGTERMS the process tree, then waits for the graceful task termination timeout. After that it sigterms the process tree.
- The kill_process_tree.sh waits half of the graceful task termination termination timeout
- command_step.sh and kill_process_tree.sh have SIGTERM traps, to not be killed when SIGTERM is received.