### PR TITLE
Fix getThreadDump method for remote nodes

### DIFF
--- a/programming-core/src/main/java/org/objectweb/proactive/core/node/NodeImpl.java
+++ b/programming-core/src/main/java/org/objectweb/proactive/core/node/NodeImpl.java
@@ -41,7 +41,6 @@ import org.objectweb.proactive.core.mop.MOPException;
 import org.objectweb.proactive.core.runtime.ProActiveRuntime;
 import org.objectweb.proactive.core.runtime.RuntimeFactory;
 import org.objectweb.proactive.core.runtime.VMInformation;
-import org.objectweb.proactive.utils.StackTraceUtil;
 
 
 /**
@@ -353,7 +352,7 @@ public class NodeImpl implements Node, Serializable {
 
     @Override
     public String getThreadDump() throws ProActiveException {
-        return StackTraceUtil.getAllStackTraces();
+        return this.proActiveRuntime.getThreadDump();
     }
 
     public VMInformation getVMInformation() {

--- a/programming-core/src/main/java/org/objectweb/proactive/core/runtime/ProActiveRuntime.java
+++ b/programming-core/src/main/java/org/objectweb/proactive/core/runtime/ProActiveRuntime.java
@@ -346,4 +346,11 @@ public interface ProActiveRuntime {
      * @return the FileTransferEngine singleton active object.
      */
     public FileTransferEngine getFileTransferEngine();
+
+    /**
+     * Returns the full thread dump of the Runtime's enclosing JVM
+     *
+     * @return thread dump
+     */
+    public String getThreadDump();
 }

--- a/programming-core/src/main/java/org/objectweb/proactive/core/runtime/ProActiveRuntimeImpl.java
+++ b/programming-core/src/main/java/org/objectweb/proactive/core/runtime/ProActiveRuntimeImpl.java
@@ -99,6 +99,7 @@ import org.objectweb.proactive.core.util.ProActiveRandom;
 import org.objectweb.proactive.core.util.URIBuilder;
 import org.objectweb.proactive.core.util.log.Loggers;
 import org.objectweb.proactive.core.util.log.ProActiveLogger;
+import org.objectweb.proactive.utils.StackTraceUtil;
 
 
 /**
@@ -1323,5 +1324,10 @@ public class ProActiveRuntimeImpl extends RuntimeRegistrationEventProducerImpl
         } else {
             throw new ProActiveException("Unable to find ProActive home. Running from class files but non standard repository layout");
         }
+    }
+
+    @Override
+    public String getThreadDump() {
+        return StackTraceUtil.getAllStackTraces();
     }
 }

--- a/programming-core/src/main/java/org/objectweb/proactive/core/runtime/ProActiveRuntimeRemoteObjectAdapter.java
+++ b/programming-core/src/main/java/org/objectweb/proactive/core/runtime/ProActiveRuntimeRemoteObjectAdapter.java
@@ -30,7 +30,6 @@ import java.lang.reflect.InvocationTargetException;
 import java.rmi.AlreadyBoundException;
 import java.util.List;
 
-import org.objectweb.proactive.Body;
 import org.objectweb.proactive.core.ProActiveException;
 import org.objectweb.proactive.core.body.UniversalBody;
 import org.objectweb.proactive.core.descriptor.data.ProActiveDescriptorInternal;
@@ -230,5 +229,10 @@ public class ProActiveRuntimeRemoteObjectAdapter extends Adapter<ProActiveRuntim
 
     public byte[] getClassData(String className) {
         return target.getClassData(className);
+    }
+
+    @Override
+    public String getThreadDump() {
+        return target.getThreadDump();
     }
 }

--- a/programming-extensions/programming-extension-dataspaces/src/test/java/dataspaces/mock/MOCKProActiveRuntime.java
+++ b/programming-extensions/programming-extension-dataspaces/src/test/java/dataspaces/mock/MOCKProActiveRuntime.java
@@ -246,4 +246,9 @@ public class MOCKProActiveRuntime implements ProActiveRuntime {
         return null;
     }
 
+    @Override
+    public String getThreadDump() {
+        return null;
+    }
+
 }


### PR DESCRIPTION
- the getThreadDump method was printing the thread dump of the local JVM instead of the JVM associated with the provided node.