### PR TITLE
add public address handling to PNP

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -162,6 +162,8 @@ project(':programming-core') {
 
                 'xerces:xercesImpl:2.11.0',
 
+                'com.google.guava:guava:19.0',
+
                 project(':programming-annotation'),
                 project(':programming-util')
         )

--- a/programming-core/src/main/java/org/objectweb/proactive/core/config/CentralPAPropertyRepository.java
+++ b/programming-core/src/main/java/org/objectweb/proactive/core/config/CentralPAPropertyRepository.java
@@ -195,6 +195,17 @@ public class CentralPAPropertyRepository implements PAPropertiesLoaderSPI {
     static public PAPropertyString PA_HOSTNAME = new PAPropertyString("proactive.hostname", false);
 
     /**
+     * ProActive Runtime Public Address (or IP Address)
+     * <p/>
+     * This option can be used when a host is behind a NAT. In that case, the host IP address is not visible outside the NAT,
+     * and a public IP address with a NAT port forwarding must be used to contact the ProActive Node.
+     *
+     * The underlying ProActive protocol must support this parameter in order to be effective.
+     * Currently, only PNP supports this parameter.
+     */
+    static public PAPropertyString PA_PUBLIC_ADDRESS = new PAPropertyString("proactive.net.public_address", false);
+
+    /**
      * Toggle DNS resolution
      * <p/>
      * When true IP addresses are used instead of FQDNs. Can be useful with misconfigured DNS servers

--- a/programming-core/src/main/java/org/objectweb/proactive/core/jmx/naming/FactoryName.java
+++ b/programming-core/src/main/java/org/objectweb/proactive/core/jmx/naming/FactoryName.java
@@ -87,7 +87,7 @@ public class FactoryName {
     public static ObjectName createActiveObjectName(UniqueID id) {
         ObjectName oname = null;
         try {
-            oname = new ObjectName(FactoryName.AO + "," + AO_ID_PROPERTY + "=" + id.getCanonString());
+            oname = new ObjectName(FactoryName.AO + "," + AO_ID_PROPERTY + "=" + ObjectName.quote(id.getCanonString()));
         } catch (MalformedObjectNameException e) {
             logger.error("Can't create the objectName of the active object", e);
         } catch (NullPointerException e) {
@@ -123,8 +123,8 @@ public class FactoryName {
 
         ObjectName oname = null;
         try {
-            oname = new ObjectName(FactoryName.NODE + "," + RUNTIME_URL_PROPERTY + "=" + runtimeUrl.replace(':', '-') +
-                                   "," + NODE_NAME_PROPERTY + "=" + nodeName.replace(':', '-'));
+            oname = new ObjectName(FactoryName.NODE + "," + RUNTIME_URL_PROPERTY + "=" + ObjectName.quote(runtimeUrl) +
+                                   "," + NODE_NAME_PROPERTY + "=" + ObjectName.quote(nodeName));
         } catch (MalformedObjectNameException e) {
             logger.error("Can't create the objectName of the node", e);
         } catch (NullPointerException e) {
@@ -143,7 +143,7 @@ public class FactoryName {
 
         ObjectName oname = null;
         try {
-            oname = new ObjectName(FactoryName.RUNTIME + "," + RUNTIME_URL_PROPERTY + "=" + url.replace(':', '-'));
+            oname = new ObjectName(FactoryName.RUNTIME + "," + RUNTIME_URL_PROPERTY + "=" + ObjectName.quote(url));
         } catch (MalformedObjectNameException e) {
             logger.error("Can't create the objectName of the runtime", e);
         } catch (NullPointerException e) {
@@ -162,8 +162,8 @@ public class FactoryName {
         ObjectName oname = null;
         try {
             oname = new ObjectName(FactoryName.VIRTUAL_NODE + "," + VIRTUAL_NODE_NAME_PROPERTY + "=" +
-                                   name.replace(':', '-') + "," + VIRTUAL_NODE_JOBID_PROPERTY + "=" +
-                                   jobID.replace(':', '-'));
+                                   ObjectName.quote(name) + "," + VIRTUAL_NODE_JOBID_PROPERTY + "=" +
+                                   ObjectName.quote(jobID));
         } catch (MalformedObjectNameException e) {
             logger.error("Can't create the objectName of the virtual node", e);
         } catch (NullPointerException e) {
@@ -183,7 +183,7 @@ public class FactoryName {
 
     /**
      * Return the JMX Server Name used for a given uri of a runtime
-     * @param runtimeUrl
+     * @param runtimeURI
      * @return The JMX Server Name
      */
     public static String getJMXServerName(URI runtimeURI) {

--- a/programming-core/src/main/java/org/objectweb/proactive/core/node/NodeImpl.java
+++ b/programming-core/src/main/java/org/objectweb/proactive/core/node/NodeImpl.java
@@ -28,6 +28,7 @@ package org.objectweb.proactive.core.node;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.Serializable;
+import java.net.URI;
 import java.util.List;
 
 import org.objectweb.proactive.ActiveObjectCreationException;
@@ -298,9 +299,8 @@ public class NodeImpl implements Node, Serializable {
          * @return String. The name of the node
          */
         private String extractNameFromUrl(String url) {
-            int n = url.lastIndexOf("/");
-            String name = url.substring(n + 1);
-            return name;
+            URI uri = URI.create(url);
+            return uri.getPath().replace("/", "");
         }
 
         public VMInformation getVMInformation() {

--- a/programming-core/src/main/java/org/objectweb/proactive/core/remoteobject/RemoteObjectExposer.java
+++ b/programming-core/src/main/java/org/objectweb/proactive/core/remoteobject/RemoteObjectExposer.java
@@ -177,7 +177,12 @@ public class RemoteObjectExposer<T> {
             // select the factory matching the required protocol
             // here is an implicit check for protocol validity
             RemoteObjectFactory rof = AbstractRemoteObjectFactory.getRemoteObjectFactory(protocol);
-            URI uri = URIBuilder.buildURI(rof.getBaseURI().getHost(), name, rof.getProtocolId(), rof.getPort());
+            URI uri = URIBuilder.buildURI(rof.getBaseURI().getUserInfo(),
+                                          rof.getBaseURI().getHost(),
+                                          name,
+                                          rof.getProtocolId(),
+                                          rof.getPort(),
+                                          null);
             InternalRemoteRemoteObject irro = activeRemoteRemoteObjects.get(uri);
             if (irro == null) {
                 irro = rof.createRemoteObject(this.remoteObject, name, rebind);

--- a/programming-core/src/main/java/org/objectweb/proactive/core/remoteobject/RemoteObjectFactory.java
+++ b/programming-core/src/main/java/org/objectweb/proactive/core/remoteobject/RemoteObjectFactory.java
@@ -67,7 +67,7 @@ public interface RemoteObjectFactory {
             throws ProActiveException;
 
     /**
-     * unregister the remote remote object located at a given
+     * unregister the remote remote object located at a given url
      *
      * @param url
      *            the url

--- a/programming-core/src/main/java/org/objectweb/proactive/core/remoteobject/RemoteObjectHelper.java
+++ b/programming-core/src/main/java/org/objectweb/proactive/core/remoteobject/RemoteObjectHelper.java
@@ -53,7 +53,7 @@ public class RemoteObjectHelper {
      */
     public static URI generateUrl(String protocol, String name) throws UnknownProtocolException {
         RemoteObjectFactory rof = AbstractRemoteObjectFactory.getRemoteObjectFactory(protocol);
-        return URIBuilder.buildURI(null, name, protocol, rof.getPort(), true);
+        return URIBuilder.buildURI(null, null, name, protocol, rof.getPort(), null, true);
     }
 
     /**

--- a/programming-core/src/main/java/org/objectweb/proactive/core/runtime/RuntimeFactory.java
+++ b/programming-core/src/main/java/org/objectweb/proactive/core/runtime/RuntimeFactory.java
@@ -163,12 +163,10 @@ public class RuntimeFactory {
         RemoteObject<ProActiveRuntime> ro = proActiveRuntime.getRemoteObjectExposer().getRemoteObject(protocol);
 
         if (ro == null) {
-            URI url = RemoteObjectHelper.generateUrl(protocol,
-                                                     URIBuilder.getNameFromURI(URI.create(proActiveRuntime.getURL())));
+            URI originalURI = URI.create(proActiveRuntime.getURL());
+            URI url = RemoteObjectHelper.generateUrl(protocol, URIBuilder.getNameFromURI(originalURI));
             proActiveRuntime.getRemoteObjectExposer().createRemoteObject(url);
             ro = proActiveRuntime.getRemoteObjectExposer().getRemoteObject(protocol);
-
-            //            throw new ProActiveException("Cannot create a ProActiveRuntime based on " + protocol);
         }
 
         return (ProActiveRuntime) RemoteObjectHelper.generatedObjectStub(ro);

--- a/programming-core/src/main/java/org/objectweb/proactive/core/util/ProActiveInet.java
+++ b/programming-core/src/main/java/org/objectweb/proactive/core/util/ProActiveInet.java
@@ -238,6 +238,13 @@ public class ProActiveInet {
         return new ArrayList<>(result);
     }
 
+    public static String getPublicAddress() {
+        if (CentralPAPropertyRepository.PA_PUBLIC_ADDRESS.isSet()) {
+            return CentralPAPropertyRepository.PA_PUBLIC_ADDRESS.getValue();
+        }
+        return null;
+    }
+
     /**
      * Returns true if the hostname property is set (force binding).
      * False otherwise

--- a/programming-core/src/test/java/org/objectweb/proactive/core/util/URITest.java
+++ b/programming-core/src/test/java/org/objectweb/proactive/core/util/URITest.java
@@ -41,12 +41,14 @@ import org.junit.Test;
 public class URITest {
     @Test
     public void checkURI() throws Exception {
-        String protocol = "rmi";
+        String protocol = "pnp";
+        String userInfo = "machine";
         String host = "localhost.localdomain";
         String path = "apath";
+        String query = "toto=value";
         int port = 1258;
 
-        URI uri = URIBuilder.buildURI(host, path, protocol, port, false);
+        URI uri = URIBuilder.buildURI(userInfo, host, path, protocol, port, query, false);
 
         // checking getters
         assertTrue(URIBuilder.getPortNumber(uri) == port);
@@ -55,9 +57,17 @@ public class URITest {
 
         assertTrue(path.equals(URIBuilder.getNameFromURI(uri)));
 
+        assertTrue(userInfo.equals(uri.getUserInfo()));
+
+        assertTrue(query.equals(uri.getQuery()));
+
         // check the remove protocol method
         URI u = URIBuilder.removeProtocol(uri);
-        assertTrue("//localhost.localdomain:1258/apath".equals(u.toString()));
+        assertTrue("//machine@localhost.localdomain:1258/apath?toto=value".equals(u.toString()));
+
+        // check the remove query method
+        u = URIBuilder.removeQuery(uri);
+        assertTrue("pnp://machine@localhost.localdomain:1258/apath".equals(u.toString()));
 
         // check the setPort method
         int port2 = 5656;
@@ -66,7 +76,7 @@ public class URITest {
 
         // check the setProtocol
         u = URIBuilder.setProtocol(uri, "http");
-        assertTrue("http://localhost.localdomain:1258/apath".equals(u.toString()));
+        assertTrue("http://machine@localhost.localdomain:1258/apath?toto=value".equals(u.toString()));
 
         // validate an URI
         try {

--- a/programming-extensions/programming-extension-gcmdeployment/src/main/java/org/objectweb/proactive/extensions/gcmdeployment/GCMApplication/GCMApplicationRemoteObjectAdapter.java
+++ b/programming-extensions/programming-extension-gcmdeployment/src/main/java/org/objectweb/proactive/extensions/gcmdeployment/GCMApplication/GCMApplicationRemoteObjectAdapter.java
@@ -87,7 +87,13 @@ public class GCMApplicationRemoteObjectAdapter extends Adapter<GCMApplication> i
 
         // Hack. Dunno how to uri.clone()
         // DO NOT use the three args version of buildURI. It silently replaces the hostname.
-        URI uri = URIBuilder.buildURI(baseUri.getHost(), name, baseUri.getScheme(), baseUri.getPort(), false);
+        URI uri = URIBuilder.buildURI(baseUri.getUserInfo(),
+                                      baseUri.getHost(),
+                                      name,
+                                      baseUri.getScheme(),
+                                      baseUri.getPort(),
+                                      baseUri.getQuery(),
+                                      false);
 
         try {
             RemoteObject ro = RemoteObjectHelper.lookup(uri);

--- a/programming-extensions/programming-extension-pnp/src/main/java/org/objectweb/proactive/extensions/pnp/PNPRemoteObjectFactoryBackend.java
+++ b/programming-extensions/programming-extension-pnp/src/main/java/org/objectweb/proactive/extensions/pnp/PNPRemoteObjectFactoryBackend.java
@@ -44,6 +44,7 @@ import org.objectweb.proactive.core.remoteobject.RemoteObjectAdapter;
 import org.objectweb.proactive.core.remoteobject.RemoteObjectFactory;
 import org.objectweb.proactive.core.remoteobject.RemoteRemoteObject;
 import org.objectweb.proactive.core.runtime.ProActiveRuntimeImpl;
+import org.objectweb.proactive.core.util.ProActiveInet;
 import org.objectweb.proactive.core.util.URIBuilder;
 import org.objectweb.proactive.core.util.converter.remote.ProActiveMarshalInputStream;
 import org.objectweb.proactive.core.util.converter.remote.ProActiveMarshalOutputStream;
@@ -230,7 +231,7 @@ public class PNPRemoteObjectFactoryBackend extends AbstractRemoteObjectFactory i
             }
 
             URI uri = new URI(this.getProtocolId(),
-                              null,
+                              ProActiveInet.getPublicAddress(),
                               URIBuilder.getHostNameorIP(this.agent.getInetAddress()),
                               this.agent.getPort(),
                               name,
@@ -253,15 +254,25 @@ public class PNPRemoteObjectFactoryBackend extends AbstractRemoteObjectFactory i
     }
 
     public URI getBaseURI() {
-        final URI uri;
+        URI uri;
+
         if (this.agent == null) {
-            uri = URI.create(this.getProtocolId() + "://pnp-failed-to-initialize-invalid-url/");
+            uri = createInvalidURI();
         } else {
-            uri = URI.create(this.getProtocolId() + "://" + URIBuilder.getHostNameorIP(this.agent.getInetAddress()) +
-                             ":" + this.agent.getPort() + "/");
+            uri = URI.create(this.getProtocolId() + "://" + getUserInfoString() +
+                             URIBuilder.getHostNameorIP(this.agent.getInetAddress()) + ":" + this.agent.getPort());
         }
 
         return uri;
+    }
+
+    private String getUserInfoString() {
+        String publicAddress = ProActiveInet.getPublicAddress();
+        return (publicAddress != null) ? publicAddress + "@" : "";
+    }
+
+    private URI createInvalidURI() {
+        return URI.create(this.getProtocolId() + "://pnp-failed-to-initialize-invalid-url/");
     }
 
     public int getPort() {

--- a/programming-extensions/programming-extension-pnp/src/main/java/org/objectweb/proactive/extensions/pnp/PNPRemoteObjectFactoryBackend.java
+++ b/programming-extensions/programming-extension-pnp/src/main/java/org/objectweb/proactive/extensions/pnp/PNPRemoteObjectFactoryBackend.java
@@ -105,20 +105,13 @@ public class PNPRemoteObjectFactoryBackend extends AbstractRemoteObjectFactory i
      * org.objectweb.proactive.core.remoteobject.RemoteObjectFactory#newRemoteObject
      * (org.objectweb .proactive.core.remoteobject.RemoteObject)
      */
+    @Override
     public RemoteRemoteObject newRemoteObject(InternalRemoteRemoteObject target) throws ProActiveException {
         throwIfAgentIsNul("newRemoteObject call failed");
 
         return new PNPRemoteObject(target, null, agent);
     }
 
-    /**
-     * Registers an remote object into the registry
-     *
-     * @param uri
-     *            The urn of the body (in fact his url + his name)
-     * @exception java.io.IOException
-     *                if the remote body cannot be registered
-     */
     /*
      * (non-Javadoc)
      *
@@ -127,6 +120,7 @@ public class PNPRemoteObjectFactoryBackend extends AbstractRemoteObjectFactory i
      * (org.objectweb.proactive .core.remoteobject.RemoteObject, java.net.URI,
      * boolean)
      */
+    @Override
     public RemoteRemoteObject register(InternalRemoteRemoteObject ro, URI uri, boolean replacePrevious)
             throws ProActiveException {
         throwIfAgentIsNul("register call failed");
@@ -139,24 +133,12 @@ public class PNPRemoteObjectFactoryBackend extends AbstractRemoteObjectFactory i
         return rro;
     }
 
-    /**
-     * Unregisters an remote object previously registered into the bodies table
-     *
-     * @param uri
-     *            the urn under which the active object has been registered
-     */
+    @Override
     public void unregister(URI uri) throws ProActiveException {
         this.registry.unbind(URIBuilder.getNameFromURI(uri));
     }
 
-    /**
-     * Looks-up a remote object previously registered in the bodies table .
-     *
-     * @param uri
-     *            the urn (in fact its url + name) the remote Body is registered
-     *            to
-     * @return a UniversalBody
-     */
+    @Override
     public RemoteObject lookup(URI uri) throws ProActiveException {
         throwIfAgentIsNul("lookup call failed");
 
@@ -175,24 +157,13 @@ public class PNPRemoteObjectFactoryBackend extends AbstractRemoteObjectFactory i
         }
     }
 
-    /**
-     * List all active object previously registered in the registry
-     *
-     * @param uri
-     *            the url of the host to scan, typically //machine_name
-     * @return a list of Strings, representing the registered names, and {} if
-     *         no registry
-     * @exception java.io.IOException
-     *                if scanning reported some problem (registry not found, or
-     *                malformed Url)
-     */
-
     /*
      * (non-Javadoc)
      *
      * @see
      * org.objectweb.proactive.core.body.BodyAdapterImpl#list(java.lang.String)
      */
+    @Override
     public URI[] list(URI uri) throws ProActiveException {
         throwIfAgentIsNul("list call failed");
 
@@ -212,14 +183,17 @@ public class PNPRemoteObjectFactoryBackend extends AbstractRemoteObjectFactory i
         }
     }
 
+    @Override
     public String getProtocolId() {
         return this.protoId;
     }
 
+    @Override
     public void unexport(RemoteRemoteObject rro) throws ProActiveException {
         // see PROACTIVE-419
     }
 
+    @Override
     public InternalRemoteRemoteObject createRemoteObject(RemoteObject<?> remoteObject, String name, boolean rebind)
             throws ProActiveException {
         throwIfAgentIsNul("createRemoteObject call failed");
@@ -230,6 +204,8 @@ public class PNPRemoteObjectFactoryBackend extends AbstractRemoteObjectFactory i
                 name = "/" + name;
             }
 
+            // the URI is constructed with a userinfo parameter if the property proactive.net.public_address is enabled
+            // in that case, the PNP remote object will have a uri such as pnp://public_address@host:port/name
             URI uri = new URI(this.getProtocolId(),
                               ProActiveInet.getPublicAddress(),
                               URIBuilder.getHostNameorIP(this.agent.getInetAddress()),
@@ -253,6 +229,7 @@ public class PNPRemoteObjectFactoryBackend extends AbstractRemoteObjectFactory i
         return this.agent;
     }
 
+    @Override
     public URI getBaseURI() {
         URI uri;
 
@@ -275,14 +252,17 @@ public class PNPRemoteObjectFactoryBackend extends AbstractRemoteObjectFactory i
         return URI.create(this.getProtocolId() + "://pnp-failed-to-initialize-invalid-url/");
     }
 
+    @Override
     public int getPort() {
         return this.agent == null ? -1 : this.agent.getPort();
     }
 
+    @Override
     public ObjectInputStream getProtocolObjectInputStream(InputStream in) throws IOException {
         return new ProActiveMarshalInputStream(in);
     }
 
+    @Override
     public ObjectOutputStream getProtocolObjectOutputStream(OutputStream out) throws IOException {
         return new ProActiveMarshalOutputStream(out, ProActiveRuntimeImpl.getProActiveRuntime().getURL());
     }

--- a/programming-test/src/test/java/functionalTests/pnp/TestPNPPublicAddress.java
+++ b/programming-test/src/test/java/functionalTests/pnp/TestPNPPublicAddress.java
@@ -1,0 +1,68 @@
+/*
+ * ProActive Parallel Suite(TM):
+ * The Open Source library for parallel and distributed
+ * Workflows & Scheduling, Orchestration, Cloud Automation
+ * and Big Data Analysis on Enterprise Grids & Clouds.
+ *
+ * Copyright (c) 2007 - 2017 ActiveEon
+ * Contact: contact@activeeon.com
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation: version 3 of
+ * the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ */
+package functionalTests.pnp;
+
+import java.net.InetAddress;
+
+import org.apache.log4j.BasicConfigurator;
+import org.junit.Assert;
+import org.junit.Test;
+import org.objectweb.proactive.api.PAActiveObject;
+import org.objectweb.proactive.core.config.CentralPAPropertyRepository;
+import org.objectweb.proactive.core.util.wrapper.BooleanWrapper;
+
+import functionalTests.FunctionalTest;
+
+
+public class TestPNPPublicAddress extends FunctionalTest {
+    @Test
+    public void testPNPNewActivePublicAddress() throws Exception {
+        BasicConfigurator.resetConfiguration();
+        BasicConfigurator.configure();
+        CentralPAPropertyRepository.PA_COMMUNICATION_PROTOCOL.setValue("pnp");
+        CentralPAPropertyRepository.PA_PUBLIC_ADDRESS.setValue(InetAddress.getLocalHost().getHostName());
+        AOTest ao = PAActiveObject.newActive(AOTest.class, new Object[0]);
+
+        String aoUrl = PAActiveObject.getUrl(ao);
+        Assert.assertTrue(aoUrl + " should contain public address user info",
+                          aoUrl.startsWith("pnp://" + InetAddress.getLocalHost().getHostName() + "@"));
+
+        ao.sayHello().getBooleanValue();
+
+        AOTest ao2 = PAActiveObject.lookupActive(AOTest.class, aoUrl);
+        ao2.sayHello().getBooleanValue();
+    }
+
+    public static class AOTest {
+        public AOTest() {
+
+        }
+
+        BooleanWrapper sayHello() {
+            return new BooleanWrapper(true);
+        }
+    }
+}


### PR DESCRIPTION
 - Added proactive.net.public_address setting. It allows to specify a hostname or ip address which can be used to contact the Remote Objects.
 - This configuration is implemented in the PNP protocol only. In case this setting is configured, the PNP protocol creates urls like pnp://public_address@private_address:port
 - To contact a Remote Object which contains a public address, the pnp protocol tries first to open a socket to the private address, and if the connection fails, it will create a socket to the public address.
 - URIBuilder methods now have userInfo and query parameters
 - Better escaping of urls in jmx FactoryName
 - added a functional test TestPNPPublicAddress