### PR TITLE
Set a constant serialVersionUid in UniqueID class

### DIFF
--- a/programming-util/src/main/java/org/objectweb/proactive/core/UniqueID.java
+++ b/programming-util/src/main/java/org/objectweb/proactive/core/UniqueID.java
@@ -43,6 +43,10 @@ import org.objectweb.proactive.annotation.PublicAPI;
 
 @PublicAPI
 public class UniqueID implements java.io.Serializable, Comparable<UniqueID> {
+
+    // Unique ID to prevent compatibility issues.
+    private static final long serialVersionUID = 1L;
+
     private java.rmi.server.UID id;
 
     private java.rmi.dgc.VMID vmID;


### PR DESCRIPTION
To prevent serialization compatibility issues, as this class is not meant to change.