### PR TITLE
Enable file cache in spaces which are not proactive-based

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -276,6 +276,7 @@ project('programming-extensions:programming-extension-dataspaces') {
     test {
         forkEvery 1
         systemProperties << ['proactive.classloading.useHTTP': false]
+        systemProperties << ['java.security.policy': file('$rootDir/compile/proactive.java.policy').absolutePath]
     }
     task stub(type: StubTask) {
         classes = ['org.objectweb.proactive.extensions.dataspaces.core.naming.NamingService']

--- a/programming-core/src/main/java/org/objectweb/proactive/core/config/CentralPAPropertyRepository.java
+++ b/programming-core/src/main/java/org/objectweb/proactive/core/config/CentralPAPropertyRepository.java
@@ -584,6 +584,24 @@ public class CentralPAPropertyRepository implements PAPropertiesLoaderSPI {
     static public PAPropertyString PA_DATASPACES_SCRATCH_PATH = new PAPropertyString("proactive.dataspaces.scratch_path",
                                                                                      false);
 
+    /**
+     * This property sets the vfs cache type to use for all dataspaces. It can be null, default, softref, lru, weakref. Default is softref.
+     *
+     * @see <a href="https://commons.apache.org/proper/commons-vfs/apidocs/org/apache/commons/vfs2/cache/package-frame.html"></a>
+     */
+    static public PAPropertyString PA_DATASPACES_CACHE_TYPE = new PAPropertyString("proactive.dataspaces.cache_type",
+                                                                                   false,
+                                                                                   "softref");
+
+    /**
+     * This property sets the vfs cache strategy to use for all dataspaces. It can be onresolve, oncall or manual. Default is onresolve.
+     *
+     * @see <a href="https://commons.apache.org/proper/commons-vfs/apidocs/org/apache/commons/vfs2/CacheStrategy.html"></a>
+     */
+    static public PAPropertyString PA_DATASPACES_CACHE_STRATEGY = new PAPropertyString("proactive.dataspaces.cache_strategy",
+                                                                                       false,
+                                                                                       "onresolve");
+
     // -------------- VFS PROVIDER
 
     /**

--- a/programming-extensions/programming-extension-dataspaces/src/test/java/dataspaces/AbstractLimitingFileObjectTest.java
+++ b/programming-extensions/programming-extension-dataspaces/src/test/java/dataspaces/AbstractLimitingFileObjectTest.java
@@ -93,7 +93,10 @@ public class AbstractLimitingFileObjectTest {
 
         realFile.delete();
 
-        assertFalse(readWriteFile.exists());
+        readOnlyFile.refresh();
+        readWriteFile.refresh();
+
+        assertFalse(readOnlyFile.exists());
         assertFalse(readWriteFile.exists());
         assertTrue(anotherFile.exists());
     }

--- a/programming-extensions/programming-extension-dataspaces/src/test/java/dataspaces/VFSNodeScratchSpaceImplTest.java
+++ b/programming-extensions/programming-extension-dataspaces/src/test/java/dataspaces/VFSNodeScratchSpaceImplTest.java
@@ -35,6 +35,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
 
+import org.apache.commons.io.FileUtils;
 import org.apache.commons.vfs2.FileObject;
 import org.apache.commons.vfs2.FileSystemException;
 import org.apache.commons.vfs2.FileType;
@@ -109,6 +110,9 @@ public class VFSNodeScratchSpaceImplTest {
     @Before
     public void setUp() throws ConfigurationException, IOException {
         testDir = new File(System.getProperty("java.io.tmpdir"), "ProActiveVFSNodeScratchSpaceImplTest");
+        if (testDir.exists()) {
+            FileUtils.deleteDirectory(testDir);
+        }
         assertTrue(testDir.mkdir());
         testDirPath = testDir.getCanonicalPath();
         localAccessConfig = new BaseScratchSpaceConfiguration(SCRATCH_URL, testDirPath);


### PR DESCRIPTION
- VFSFactory now exposes additional methods to create proactive-based or non-proactive-based file system managers
- VFSMountManagerHelper now create two file system managers, one for proactive file system and one for non-proactive
- added a property to configure the cache strategy (onresolve, manual, etc)