### PR TITLE
Improvements in ProActive Dataspaces

### DIFF
--- a/programming-core/src/main/java/org/objectweb/proactive/core/config/CentralPAPropertyRepository.java
+++ b/programming-core/src/main/java/org/objectweb/proactive/core/config/CentralPAPropertyRepository.java
@@ -618,6 +618,13 @@ public class CentralPAPropertyRepository implements PAPropertiesLoaderSPI {
     static public PAPropertyInteger PA_VFSPROVIDER_SERVER_STREAM_OPEN_MAXIMUM_PERIOD_MILLIS = new PAPropertyInteger("proactive.vfsprovider.server.stream_open_maximum_period_millis",
                                                                                                                     false);
 
+    /**
+     * This property indicates the number of threads used to find files in a remote ProActive virtual file system.
+     * A number <= 1 indicates that parallel processing is disabled when finding files
+     */
+    static public PAPropertyInteger PA_VFSPROVIDER_CLIENT_FIND_FILES_THREAD_NUMBER = new PAPropertyInteger("proactive.vfsprovider.client.find_files_thread_number",
+                                                                                                           false);
+
     // -------------- Misc
 
     /**

--- a/programming-extensions/programming-extension-dataspaces/src/test/java/dataspaces/PatternDepthFileSelector.java
+++ b/programming-extensions/programming-extension-dataspaces/src/test/java/dataspaces/PatternDepthFileSelector.java
@@ -1,0 +1,80 @@
+/*
+ * ProActive Parallel Suite(TM):
+ * The Open Source library for parallel and distributed
+ * Workflows & Scheduling, Orchestration, Cloud Automation
+ * and Big Data Analysis on Enterprise Grids & Clouds.
+ *
+ * Copyright (c) 2007 - 2017 ActiveEon
+ * Contact: contact@activeeon.com
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation: version 3 of
+ * the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ */
+package dataspaces;
+
+import java.util.Collection;
+
+import org.apache.commons.vfs2.FileSelectInfo;
+import org.objectweb.proactive.extensions.dataspaces.vfs.selector.FileSelector;
+
+
+/**
+ * @author ActiveEon Team
+ * @since 12/07/2017
+ */
+public class PatternDepthFileSelector extends FileSelector {
+
+    private final int maxDepth;
+
+    private final int minDepth;
+
+    public PatternDepthFileSelector() {
+        super();
+        minDepth = 0;
+        maxDepth = Integer.MAX_VALUE;
+    }
+
+    public PatternDepthFileSelector(int minDepth, int maxDepth, Collection<String> includes,
+            Collection<String> excludes) {
+        super(includes, excludes);
+        this.minDepth = minDepth;
+        this.maxDepth = maxDepth;
+    }
+
+    public PatternDepthFileSelector(int minDepth, int maxDepth, String[] includes, String[] excludes) {
+        super(includes, excludes);
+        this.minDepth = minDepth;
+        this.maxDepth = maxDepth;
+    }
+
+    public PatternDepthFileSelector(int minDepth, int maxDepth, String... includes) {
+        super(includes);
+        this.minDepth = minDepth;
+        this.maxDepth = maxDepth;
+    }
+
+    @Override
+    public boolean includeFile(FileSelectInfo fileInfo) throws Exception {
+        int depth = fileInfo.getDepth();
+        return (depth >= minDepth && depth <= maxDepth) && super.includeFile(fileInfo);
+    }
+
+    @Override
+    public boolean traverseDescendents(FileSelectInfo fileInfo) throws Exception {
+        return (fileInfo.getDepth() < maxDepth) && super.traverseDescendents(fileInfo);
+    }
+
+}

--- a/programming-extensions/programming-extension-dataspaces/src/test/java/dataspaces/ProActiveFileObjectTest.java
+++ b/programming-extensions/programming-extension-dataspaces/src/test/java/dataspaces/ProActiveFileObjectTest.java
@@ -1,0 +1,129 @@
+/*
+ * ProActive Parallel Suite(TM):
+ * The Open Source library for parallel and distributed
+ * Workflows & Scheduling, Orchestration, Cloud Automation
+ * and Big Data Analysis on Enterprise Grids & Clouds.
+ *
+ * Copyright (c) 2007 - 2017 ActiveEon
+ * Contact: contact@activeeon.com
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation: version 3 of
+ * the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ */
+package dataspaces;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.apache.commons.vfs2.FileObject;
+import org.apache.commons.vfs2.impl.DefaultFileSystemManager;
+import org.apache.log4j.BasicConfigurator;
+import org.apache.log4j.Level;
+import org.apache.log4j.Logger;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.objectweb.proactive.core.util.log.Loggers;
+import org.objectweb.proactive.extensions.dataspaces.vfs.VFSFactory;
+import org.objectweb.proactive.extensions.dataspaces.vfs.selector.FileSelector;
+import org.objectweb.proactive.extensions.vfsprovider.FileSystemServerDeployer;
+import org.objectweb.proactive.extensions.vfsprovider.client.ProActiveFileObject;
+
+
+/**
+ * This test checks finding files for ProActiveFileObject
+ * It may be improved later on to test other ProActiveFileObject features
+ * @author ActiveEon Team
+ * @since 10/07/2017
+ */
+public class ProActiveFileObjectTest {
+
+    @ClassRule
+    public static TemporaryFolder tempFolder = new TemporaryFolder();
+
+    static File createdFolder;
+
+    static final int NB_FILES_PATTERN = 5000;
+
+    static final String FOLDER_PATTERN = "findFiles/subfolder";
+
+    static final String DEPTH_FOLDER_PATTERN = "findFiles";
+
+    static FileSystemServerDeployer deployer;
+
+    static DefaultFileSystemManager manager;
+
+    static String proActiveFSURL;
+
+    @BeforeClass
+    public static void setUp() throws IOException {
+
+        BasicConfigurator.resetConfiguration();
+        BasicConfigurator.configure();
+        Logger.getLogger(Loggers.VFS_PROVIDER_SERVER).setLevel(Level.TRACE);
+        createdFolder = tempFolder.newFolder();
+        deployer = new FileSystemServerDeployer(createdFolder.getAbsolutePath(), false);
+        for (String url : deployer.getVFSRootURLs()) {
+            if (!url.startsWith("file:")) {
+                proActiveFSURL = url;
+            }
+        }
+        manager = VFSFactory.createDefaultFileSystemManager();
+
+        generateFiles();
+    }
+
+    private static void generateFiles() throws IOException {
+        int nbFiles = NB_FILES_PATTERN;
+        File patternFindFilesFolder = new File(createdFolder, FOLDER_PATTERN);
+        patternFindFilesFolder.mkdirs();
+
+        File patternFindFilesDepthFolder = new File(createdFolder, DEPTH_FOLDER_PATTERN);
+        patternFindFilesDepthFolder.mkdirs();
+        for (int i = 0; i < nbFiles; i++) {
+            File fileToFindWithPatternTest = new File(patternFindFilesFolder, "file_" + i + ".in");
+            fileToFindWithPatternTest.createNewFile();
+
+            File fileToFindWithPatternDepthTest = new File(patternFindFilesDepthFolder, "file_" + i + ".in");
+            fileToFindWithPatternDepthTest.createNewFile();
+        }
+    }
+
+    @Test
+    public void testFindFilesWithPattern() throws IOException {
+        FileObject rootFO = manager.resolveFile(proActiveFSURL);
+        FileObject[] answer = rootFO.findFiles(new FileSelector(FOLDER_PATTERN + "/*.in"));
+        assertEquals(NB_FILES_PATTERN, answer.length);
+    }
+
+    @Test
+    public void testFindFilesWithPatternAndDepth() throws IOException {
+        FileObject rootFO = manager.resolveFile(proActiveFSURL);
+        FileObject[] answer = rootFO.findFiles(new PatternDepthFileSelector(0, 2, "**/*.in"));
+        assertEquals(NB_FILES_PATTERN, answer.length);
+    }
+
+    @AfterClass
+    public static void clean() throws Exception {
+        manager.close();
+        deployer.terminate();
+    }
+}

--- a/programming-extensions/programming-extension-vfsprovider/src/main/java/org/objectweb/proactive/extensions/dataspaces/vfs/VFSFactory.java
+++ b/programming-extensions/programming-extension-vfsprovider/src/main/java/org/objectweb/proactive/extensions/dataspaces/vfs/VFSFactory.java
@@ -141,13 +141,8 @@ public class VFSFactory {
 
         final DefaultFileSystemManager manager = buildManager();
 
-        if (managerType == ManagerType.PROACTIVE) {
-            // WISH: one beautiful day one may try to use FilesCache aware of AO instead of NullFilesCache
-            manager.setFilesCache(new NullFilesCache());
-        } else {
-            manager.setFilesCache(getCacheType());
-            manager.setCacheStrategy(getCacheStrategy());
-        }
+        manager.setFilesCache(getCacheType());
+        manager.setCacheStrategy(getCacheStrategy());
 
         if (managerType == ManagerType.NON_PROACTIVE || managerType == ManagerType.BOTH) {
             addNonProActiveProviders(manager);

--- a/programming-extensions/programming-extension-vfsprovider/src/main/java/org/objectweb/proactive/extensions/vfsprovider/client/ProActiveFileObject.java
+++ b/programming-extensions/programming-extension-vfsprovider/src/main/java/org/objectweb/proactive/extensions/vfsprovider/client/ProActiveFileObject.java
@@ -31,13 +31,16 @@ import java.io.FilterInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.RecursiveTask;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
-import org.apache.commons.vfs2.FileName;
 import org.apache.commons.vfs2.FileObject;
+import org.apache.commons.vfs2.FileSelectInfo;
+import org.apache.commons.vfs2.FileSelector;
 import org.apache.commons.vfs2.FileSystemException;
 import org.apache.commons.vfs2.FileType;
 import org.apache.commons.vfs2.RandomAccessContent;
@@ -48,11 +51,17 @@ import org.apache.commons.vfs2.provider.UriParser;
 import org.apache.commons.vfs2.util.MonitorInputStream;
 import org.apache.commons.vfs2.util.MonitorOutputStream;
 import org.apache.commons.vfs2.util.RandomAccessMode;
+import org.apache.log4j.Logger;
+import org.objectweb.proactive.core.config.CentralPAPropertyRepository;
+import org.objectweb.proactive.core.util.log.Loggers;
+import org.objectweb.proactive.core.util.log.ProActiveLogger;
 import org.objectweb.proactive.extensions.vfsprovider.exceptions.StreamNotFoundException;
 import org.objectweb.proactive.extensions.vfsprovider.exceptions.WrongStreamTypeException;
 import org.objectweb.proactive.extensions.vfsprovider.protocol.FileInfo;
 import org.objectweb.proactive.extensions.vfsprovider.protocol.FileSystemServer;
 import org.objectweb.proactive.extensions.vfsprovider.protocol.StreamMode;
+
+import com.google.common.collect.Lists;
 
 
 /**
@@ -60,9 +69,26 @@ import org.objectweb.proactive.extensions.vfsprovider.protocol.StreamMode;
  *
  * @see ProActiveFileProvider
  */
-public class ProActiveFileObject extends AbstractFileObject {
-    // logging in VFS (not ProActive) way
-    private static Log log = LogFactory.getLog(ProActiveFileObject.class);
+public class ProActiveFileObject extends AbstractFileObject<ProActiveFileSystem> {
+
+    private static final int DEFAULT_NUMBER_OF_THREADS = Runtime.getRuntime().availableProcessors() * 2 - 1;
+
+    // log4j logger
+    private static Logger logger = ProActiveLogger.getLogger(Loggers.VFS_PROVIDER_SERVER);
+
+    // fork join pool is supposed to be thread safe, and all threads started are in daemon mode, not requiring an explicit shutdown
+    private static final ForkJoinPool forkJoinPool;
+
+    static {
+        int configuredNumberOfThreads = getConfiguredNumberOfThreads();
+        if (configuredNumberOfThreads > 1) {
+            forkJoinPool = new ForkJoinPool(getConfiguredNumberOfThreads());
+        } else {
+            // find files parallelization disabled
+            forkJoinPool = null;
+        }
+
+    }
 
     private static final FileInfo IMAGINARY_FILE_INFO = new FileInfo() {
 
@@ -101,8 +127,7 @@ public class ProActiveFileObject extends AbstractFileObject {
     }
 
     private ProActiveFileObject(AbstractFileName name, FileInfo info, ProActiveFileSystem fs) {
-        super(name, fs);
-        this.proactiveFS = fs;
+        this(name, fs);
         this.fileInfo = info;
     }
 
@@ -239,6 +264,47 @@ public class ProActiveFileObject extends AbstractFileObject {
     }
 
     @Override
+    public List<FileObject> listFiles(final FileSelector selector) throws FileSystemException {
+        if (!exists() || selector == null) {
+            return null;
+        }
+
+        final ArrayList<FileObject> list = new ArrayList<FileObject>();
+        this.findFiles(selector, true, list);
+        return list;
+    }
+
+    @Override
+    public FileObject[] findFiles(final FileSelector selector) throws FileSystemException {
+        final List<FileObject> list = this.listFiles(selector);
+        return list == null ? null : list.toArray(new FileObject[list.size()]);
+    }
+
+    @Override
+    public void findFiles(final FileSelector selector, final boolean depthwise, final List<FileObject> selected)
+            throws FileSystemException {
+        if (forkJoinPool == null) {
+            // findFiles parallelization is disabled, use default implementation
+            super.findFiles(selector, depthwise, selected);
+        } else {
+            // findFiles parallelization is enabled, use custom parallel implementation
+            try {
+                if (exists()) {
+                    // Traverse starting at this file
+                    final DefaultFileSelectorInfo info = new DefaultFileSelectorInfo();
+                    info.setBaseFolder(this);
+                    info.setDepth(0);
+                    info.setFile(this);
+
+                    selected.addAll(forkJoinPool.invoke(new TraverseFilesTask(info, selector, depthwise)));
+                }
+            } catch (final Exception e) {
+                throw new FileSystemException("vfs.provider/find-files.error", getName(), e);
+            }
+        }
+    }
+
+    @Override
     protected void doCreateFolder() throws Exception {
         synchronized (proactiveFS) {
             getServer().fileCreate(getPath(),
@@ -309,7 +375,7 @@ public class ProActiveFileObject extends AbstractFileObject {
 
         @Override
         protected void reopenStream() throws IOException {
-            ProActiveFileObject.log.debug("Reopening input stream: " + streamId);
+            ProActiveFileObject.logger.debug("Reopening input stream: " + streamId);
             try {
                 streamId = getServer().streamOpen(getPath(), StreamMode.SEQUENTIAL_READ);
                 if (position > 0) {
@@ -320,7 +386,7 @@ public class ProActiveFileObject extends AbstractFileObject {
                     }
                 }
             } catch (Exception x) {
-                throw Utils.generateAndLogIOExceptionCouldNotReopen(log, x);
+                throw Utils.generateAndLogIOExceptionCouldNotReopen(logger, x);
             }
         }
     }
@@ -359,11 +425,11 @@ public class ProActiveFileObject extends AbstractFileObject {
 
         @Override
         protected void reopenStream() throws IOException {
-            ProActiveFileObject.log.debug("Reopening output stream: " + streamId);
+            ProActiveFileObject.logger.debug("Reopening output stream: " + streamId);
             try {
                 streamId = getServer().streamOpen(getPath(), StreamMode.SEQUENTIAL_APPEND);
             } catch (Exception x) {
-                throw Utils.generateAndLogIOExceptionCouldNotReopen(log, x);
+                throw Utils.generateAndLogIOExceptionCouldNotReopen(logger, x);
             }
         }
     }
@@ -570,11 +636,11 @@ public class ProActiveFileObject extends AbstractFileObject {
         }
 
         private void reopenStream() throws IOException {
-            ProActiveFileObject.log.debug("Reopening random access stream: " + streamId);
+            ProActiveFileObject.logger.debug("Reopening random access stream: " + streamId);
             try {
                 streamId = getServer().streamOpen(getPath(), streamMode);
             } catch (Exception x) {
-                throw Utils.generateAndLogIOExceptionCouldNotReopen(log, x);
+                throw Utils.generateAndLogIOExceptionCouldNotReopen(logger, x);
             }
 
             if (position > 0) {
@@ -582,7 +648,7 @@ public class ProActiveFileObject extends AbstractFileObject {
                     getServer().streamSeek(streamId, position);
                 } catch (Exception x) {
                     close();
-                    throw Utils.generateAndLogIOExceptionCouldNotReopen(log, x);
+                    throw Utils.generateAndLogIOExceptionCouldNotReopen(logger, x);
                 }
             }
         }
@@ -627,9 +693,9 @@ public class ProActiveFileObject extends AbstractFileObject {
                     return getServer().streamGetLength(streamId);
                 }
             } catch (WrongStreamTypeException e) {
-                throw Utils.generateAndLogIOExceptionWrongStreamType(log, e);
+                throw Utils.generateAndLogIOExceptionWrongStreamType(logger, e);
             } catch (StreamNotFoundException e) {
-                throw Utils.generateAndLogIOExceptionStreamNotFound(log, e);
+                throw Utils.generateAndLogIOExceptionStreamNotFound(logger, e);
             }
         }
 
@@ -647,9 +713,9 @@ public class ProActiveFileObject extends AbstractFileObject {
                     getDataInputStream().close();
                 }
             } catch (WrongStreamTypeException e) {
-                throw Utils.generateAndLogIOExceptionWrongStreamType(log, e);
+                throw Utils.generateAndLogIOExceptionWrongStreamType(logger, e);
             } catch (StreamNotFoundException e) {
-                throw Utils.generateAndLogIOExceptionStreamNotFound(log, e);
+                throw Utils.generateAndLogIOExceptionStreamNotFound(logger, e);
             }
         }
 
@@ -735,6 +801,131 @@ public class ProActiveFileObject extends AbstractFileObject {
         public void writeUTF(String str) throws IOException {
             checkStreamModeReadWrite();
             getDataOutputStream().writeUTF(str);
+        }
+    }
+
+    static final class DefaultFileSelectorInfo implements FileSelectInfo {
+        private FileObject baseFolder;
+
+        private FileObject file;
+
+        private int depth;
+
+        @Override
+        public FileObject getBaseFolder() {
+            return baseFolder;
+        }
+
+        public void setBaseFolder(final FileObject baseFolder) {
+            this.baseFolder = baseFolder;
+        }
+
+        @Override
+        public FileObject getFile() {
+            return file;
+        }
+
+        public void setFile(final FileObject file) {
+            this.file = file;
+        }
+
+        @Override
+        public int getDepth() {
+            return depth;
+        }
+
+        public void setDepth(final int depth) {
+            this.depth = depth;
+        }
+    }
+
+    private static int getConfiguredNumberOfThreads() {
+        if (CentralPAPropertyRepository.PA_VFSPROVIDER_CLIENT_FIND_FILES_THREAD_NUMBER.isSet()) {
+            try {
+                return CentralPAPropertyRepository.PA_VFSPROVIDER_CLIENT_FIND_FILES_THREAD_NUMBER.getValue();
+            } catch (Exception e) {
+                logger.error("Invalid value for " +
+                             CentralPAPropertyRepository.PA_VFSPROVIDER_CLIENT_FIND_FILES_THREAD_NUMBER.getName(), e);
+                return DEFAULT_NUMBER_OF_THREADS;
+            }
+        } else {
+            return DEFAULT_NUMBER_OF_THREADS;
+        }
+    }
+
+    static final class TraverseFilesTask extends RecursiveTask<List<FileObject>> {
+
+        final DefaultFileSelectorInfo fileInfo;
+
+        final FileSelector selector;
+
+        final boolean depthwise;
+
+        public TraverseFilesTask(DefaultFileSelectorInfo fileSelectorInfo, FileSelector selector, boolean depthwise) {
+            this.fileInfo = fileSelectorInfo;
+            this.selector = selector;
+            this.depthwise = depthwise;
+        }
+
+        @Override
+        protected List<FileObject> compute() {
+            // Check the file itself
+            final FileObject file = fileInfo.getFile();
+
+            final int curDepth = fileInfo.getDepth();
+
+            List<FileObject> answer = Lists.newArrayList();
+
+            try {
+
+                if (depthwise && selector.includeFile(fileInfo)) {
+                    if (logger.isTraceEnabled()) {
+                        logger.trace("Selector ( " + selector + " ) Found file : " + file.getName() + " depth=" +
+                                     curDepth);
+                    }
+                    answer.add(file);
+                } else if (logger.isTraceEnabled()) {
+                    logger.trace("Selector ( " + selector + " ) Rejected file : " + file.getName() + " depth=" +
+                                 curDepth);
+                }
+
+                // If the file is a folder, traverse it
+                if (file.getType().hasChildren() && selector.traverseDescendents(fileInfo)) {
+
+                    // Traverse the children
+                    final FileObject[] children = file.getChildren();
+                    List<TraverseFilesTask> subTasks = Lists.newArrayListWithCapacity(children.length);
+                    for (final FileObject child : children) {
+                        final DefaultFileSelectorInfo subInfo = new DefaultFileSelectorInfo();
+                        subInfo.setBaseFolder(fileInfo.getBaseFolder());
+                        subInfo.setDepth(curDepth + 1);
+                        subInfo.setFile(child);
+                        if (logger.isTraceEnabled()) {
+                            logger.trace("Selector ( " + selector + " ) Traversing : " + child.getName());
+                        }
+
+                        TraverseFilesTask subTask = new TraverseFilesTask(subInfo, selector, depthwise);
+                        subTasks.add(subTask);
+
+                        subTask.fork();
+                    }
+                    for (TraverseFilesTask subTask : subTasks) {
+                        answer.addAll(subTask.join());
+                    }
+                }
+                if (!depthwise && selector.includeFile(fileInfo)) {
+                    if (logger.isTraceEnabled()) {
+                        logger.trace("Selector ( " + selector + " ) Found file : " + file.getName());
+                    }
+                    answer.add(file);
+                }
+            } catch (Exception e) {
+                logger.error("Error occurred when recursively analysing " + file.getName() + " for selector " +
+                             selector, e);
+                throw new RuntimeException("Error occurred when recursively analysing " + file.getName() +
+                                           " for selector " + selector, e);
+            }
+            return answer;
         }
     }
 }

--- a/programming-extensions/programming-extension-vfsprovider/src/main/java/org/objectweb/proactive/extensions/vfsprovider/client/Utils.java
+++ b/programming-extensions/programming-extension-vfsprovider/src/main/java/org/objectweb/proactive/extensions/vfsprovider/client/Utils.java
@@ -28,6 +28,7 @@ package org.objectweb.proactive.extensions.vfsprovider.client;
 import java.io.IOException;
 
 import org.apache.commons.logging.Log;
+import org.apache.log4j.Logger;
 import org.objectweb.proactive.core.exceptions.IOException6;
 import org.objectweb.proactive.extensions.vfsprovider.exceptions.StreamNotFoundException;
 import org.objectweb.proactive.extensions.vfsprovider.exceptions.WrongStreamTypeException;
@@ -43,12 +44,28 @@ class Utils {
                                 e);
     }
 
+    public static IOException generateAndLogIOExceptionWrongStreamType(Logger log, WrongStreamTypeException e) {
+        log.error("File server unexpectedly does not allow to perform some type of operation on an opened stream");
+        return new IOException6("File server unexpectedly does not allow to perform some type of operation on an opened stream",
+                                e);
+    }
+
     public static IOException generateAndLogIOExceptionStreamNotFound(Log log, StreamNotFoundException e) {
         log.error("File server unexpectedly closed (possibly reopened) file stream");
         return new IOException6("File server unexpectedly closed (possibly reopened) file stream", e);
     }
 
+    public static IOException generateAndLogIOExceptionStreamNotFound(Logger log, StreamNotFoundException e) {
+        log.error("File server unexpectedly closed (possibly reopened) file stream");
+        return new IOException6("File server unexpectedly closed (possibly reopened) file stream", e);
+    }
+
     public static IOException generateAndLogIOExceptionCouldNotReopen(Log log, Exception x) {
+        log.error("Could not reopen stream correctly");
+        return new IOException6("Could not reopen stream correctly", x);
+    }
+
+    public static IOException generateAndLogIOExceptionCouldNotReopen(Logger log, Exception x) {
         log.error("Could not reopen stream correctly");
         return new IOException6("Could not reopen stream correctly", x);
     }

--- a/programming-extensions/programming-extension-vfsprovider/src/main/java/org/objectweb/proactive/extensions/vfsprovider/server/FileSystemServerImpl.java
+++ b/programming-extensions/programming-extension-vfsprovider/src/main/java/org/objectweb/proactive/extensions/vfsprovider/server/FileSystemServerImpl.java
@@ -54,6 +54,8 @@ import org.objectweb.proactive.extensions.vfsprovider.protocol.FileSystemServer;
 import org.objectweb.proactive.extensions.vfsprovider.protocol.FileType;
 import org.objectweb.proactive.extensions.vfsprovider.protocol.StreamMode;
 
+import com.google.common.collect.Sets;
+
 
 // TODO idea: now we export existing directory, shall we allow to export a file?
 /**
@@ -391,7 +393,7 @@ public class FileSystemServerImpl implements FileSystemServer {
         if (list == null) {
             return null;
         }
-        return new HashSet<String>(Arrays.asList(list));
+        return Sets.newHashSet(list);
     }
 
     public Map<String, FileInfo> fileListChildrenInfo(String path) throws IOException {


### PR DESCRIPTION
- FileSelector: improved FileSelector to prune branches which do not match the selector "so far". AntPathMatcher is used to determine if a branch should be pruned (traverseDescendants method). Pattern compilation is also cached to improve performance
- Added tests in TestFileSelector related to this change.
- VFSFactory: use a single FileSystemManager for both ProActive and non-ProActive file systems, the same cache configuration will be used for all file systems.
- ProActiveFileObject: override the doListChildrenResolved method to generate an array of FileObjects. This change improves performance drastically in case of a large number of files.
- ProActiveFileObject: use the ForkJoin framework to execute in parallel the recursive find algorithm