### PR TITLE
Add PAMR+SSH support for cloud-provided VMs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,5 @@ bin/
 # /src/Tests/functionalTests/component/conform/membranes/
 /src/Tests/functionalTests/component/conform/membranes/julia.cfg
 /.nb-gradle/private/
+
+out/

--- a/programming-core/src/main/java/org/objectweb/proactive/core/ssh/SshConfig.java
+++ b/programming-core/src/main/java/org/objectweb/proactive/core/ssh/SshConfig.java
@@ -310,6 +310,22 @@ public class SshConfig {
     }
 
     /**
+     * Returns a resolvable host name for the associated public <code>host</code> provided.
+     * If none is defined, returns the public host provided.
+     *
+     * @param host the public host name of the remote-side of the SSH Tunnel
+     * @return A host name the remote-side of the SSH Tunnel can resolve
+     */
+    public String getHostName(String host) {
+        String hostName = getInformation(host, SshToken.HOSTNAME);
+        if (hostName != null) {
+            return hostName;
+        } else {
+            return host;
+        }
+    }
+
+    /**
      * Never return null, if no information stored, return ssh default private key
      */
     public String[] getPrivateKeyPath(String host) throws IOException {
@@ -427,9 +443,9 @@ public class SshConfig {
         this.sshDirPath = sshDirPath;
     }
 
-    public void setKnowHostFile(String knownHostfile) {
+    public void setKnowHostFile(String knownHostFile) {
         checkReadOnly();
-        this.knownHostFile = knownHostfile;
+        this.knownHostFile = knownHostFile;
     }
 
     public String getKnowHostFile() {

--- a/programming-core/src/main/java/org/objectweb/proactive/core/ssh/SshConnection.java
+++ b/programming-core/src/main/java/org/objectweb/proactive/core/ssh/SshConnection.java
@@ -129,29 +129,27 @@ public class SshConnection {
     /** Open a SSH tunnel to remoteHost:remotePort over the SSH connection
      * 
      * A free port is automatically chosen as local port
-     * 
-     * @param connection The SSH connection to use to create the tunnel
+     *
      * @param remoteHost The remote host
      * @param remotePort The remote TCP port 
      * 
      * @throws IOException if the tunnel cannot be opened
      */
-    synchronized public SshTunnel getSSHTunnel(String remotetHost, int remotePort) throws IOException {
-        return SshTunnel.getSshTunnel(this, remotetHost, remotePort);
+    synchronized public SshTunnel getSSHTunnel(String remoteHost, int remotePort) throws IOException {
+        return SshTunnel.getSshTunnel(this, remoteHost, remotePort);
     }
 
     /** Open a SSH tunnel to remoteHost:remotePort over the SSH connection
-     * 
-     * @param connection The SSH connection to use to create the tunnel
+     *
      * @param remoteHost The remote host
      * @param remotePort The remote TCP port
-     * @param localport  The local TCP port to bind to
+     * @param localPort  The local TCP port to bind to
      * 
      * @throws IOException if the tunnel cannot be opened
-     * @throws BindException if localport is not free
+     * @throws BindException if localPort is not free
      */
-    synchronized public SshTunnel getSSHTunnel(String remotetHost, int remotePort, int localport) throws IOException {
-        return new SshTunnel(this, remotetHost, remotePort, localport);
+    synchronized public SshTunnel getSSHTunnel(String remoteHost, int remotePort, int localPort) throws IOException {
+        return new SshTunnel(this, remoteHost, remotePort, localPort);
     }
 
     /** Close this connection

--- a/programming-core/src/main/java/org/objectweb/proactive/core/ssh/SshTunnel.java
+++ b/programming-core/src/main/java/org/objectweb/proactive/core/ssh/SshTunnel.java
@@ -95,27 +95,27 @@ public class SshTunnel {
         throw new BindException("No free local port found");
     }
 
-    /** Open a SSH tunnel between the localhost:localport and remoteHost:remotePort over the SSH connection
+    /** Open a SSH tunnel between the localhost:localPort and remoteHost:remotePort over the SSH connection
      * 
      * @param connection The SSH connection to use to create the tunnel
      * @param remoteHost The remote host
      * @param remotePort The remote TCP port 
-     * @param localport  The local TCP port to bind to. 
+     * @param localPort  The local TCP port to bind to.
      * 
      * @throws IOException if the tunnel cannot be opened
      * 
      * @see {@link #getSshTunnel(SshConnection, String, int)}
      */
-    SshTunnel(SshConnection connection, String remoteHost, int remotePort, int localport) throws IOException {
+    SshTunnel(SshConnection connection, String remoteHost, int remotePort, int localPort) throws IOException {
         this.remoteHost = remoteHost;
         this.remotePort = remotePort;
-        this.localPort = localport;
-        InetSocketAddress isa = new InetSocketAddress(ProActiveInet.getInstance().getInetAddress(), localport);
+        this.localPort = localPort;
+        InetSocketAddress isa = new InetSocketAddress(ProActiveInet.getInstance().getInetAddress(), localPort);
         this.lpf = connection.getTrileadConnection().createLocalPortForwarder(isa, remoteHost, remotePort);
 
         if (logger.isDebugEnabled()) {
-            logger.debug("Opened SSH tunnel localport=" + localPort + " distantHost=" + remoteHost + " distantPort=" +
-                         remotePort);
+            logger.debug("Opened SSH tunnel localPort=" + this.localPort + " distantHost=" + remoteHost +
+                         " distantPort=" + remotePort);
         }
     }
 

--- a/programming-extensions/programming-extension-pamr/src/main/java/org/objectweb/proactive/extensions/pamr/PAMRConfig.java
+++ b/programming-extensions/programming-extension-pamr/src/main/java/org/objectweb/proactive/extensions/pamr/PAMRConfig.java
@@ -120,7 +120,11 @@ public class PAMRConfig implements PAPropertiesLoaderSPI {
      * PAMR over SSH
      */
 
-    /** this property identifies the location of RMISSH key directory */
+    /**
+     * This property identifies the location of SSH key directory.
+     * This directory shall contain both public and private keys.
+     *
+     * */
     static public PAPropertyString PA_PAMRSSH_KEY_DIR = new PAPropertyString("proactive.pamrssh.key_directory", false);
 
     /** this property identifies the PAMR over SSH garbage collector period
@@ -150,11 +154,25 @@ public class PAMRConfig implements PAPropertiesLoaderSPI {
                                                                                        false,
                                                                                        60000);
 
-    // Not documented, temporary workaround until 4.3.0
+    /**
+     * This property is used when a SSH Tunnel is opened. The address can be either a hostname or an IP.
+     * The value will be used to bind the remote-side of the SSH Tunnel to the same network interface as the
+     * PAMR Router (by resolving the hostname to the IP, then to the right interface).
+     *
+     */
+    static public PAPropertyString PA_PAMRSSH_REMOTE_ADDRESS = new PAPropertyString("proactive.pamrssh.address", false);
+
+    /**
+     * This property defines which username to use to SSH into the remote machine hosting the PAMR router.
+     *
+     */
     static public PAPropertyString PA_PAMRSSH_REMOTE_USERNAME = new PAPropertyString("proactive.pamrssh.username",
                                                                                      false);
 
-    // Not documented, temporary workaround until 4.3.0
+    /**
+     * This property defines which SSH port to use to establish the SSH Connection. Usually binds to 22.
+     *
+     */
     static public PAPropertyInteger PA_PAMRSSH_REMOTE_PORT = new PAPropertyInteger("proactive.pamrssh.port", false);
 
     /*

--- a/programming-extensions/programming-extension-pamr/src/main/java/org/objectweb/proactive/extensions/pamr/client/AgentImpl.java
+++ b/programming-extensions/programming-extension-pamr/src/main/java/org/objectweb/proactive/extensions/pamr/client/AgentImpl.java
@@ -250,7 +250,7 @@ public class AgentImpl implements Agent, AgentImplMBean {
                 this.te = null;
             } catch (Exception e) {
                 logger.warn("PAMR Router " + this.routerAddr + ":" + this.routerPort + " is unreachable (" +
-                            e.getMessage() + "). Will try to estalish a new tunnel in " + (delay / 1000) + " seconds");
+                            e.getMessage() + "). Will try to establish a new tunnel in " + (delay / 1000) + " seconds");
 
                 // To have the full stack trace in case something goes really wrong
                 logger.debug("Failed to connect to the PAMR router", e);
@@ -271,8 +271,11 @@ public class AgentImpl implements Agent, AgentImplMBean {
      */
     private Tunnel __reconnectToRouter() throws Exception {
         Tunnel t = null;
+        String hostAddress = this.routerAddr.getHostAddress();
+        int routerPort = this.routerPort;
 
-        Socket s = socketFactory.createSocket(this.routerAddr.getHostAddress(), this.routerPort);
+        logger.debug("Opening socket to " + hostAddress + ":" + routerPort);
+        Socket s = socketFactory.createSocket(hostAddress, routerPort);
         Tunnel tunnel = new Tunnel(s);
 
         // start router handshake
@@ -610,7 +613,7 @@ public class AgentImpl implements Agent, AgentImplMBean {
 
         /**
          * Unblock the Patient waiting on a particular messageID
-         * @param agentId
+         * @param messageId
          */
         private Patient unlockDueToCorruption(Long messageId) {
             AgentID agent = null;

--- a/programming-extensions/programming-extension-pamr/src/main/java/org/objectweb/proactive/extensions/pamr/remoteobject/util/socketfactory/PAMRSshSocketFactory.java
+++ b/programming-extensions/programming-extension-pamr/src/main/java/org/objectweb/proactive/extensions/pamr/remoteobject/util/socketfactory/PAMRSshSocketFactory.java
@@ -73,8 +73,8 @@ public class PAMRSshSocketFactory implements PAMRSocketFactorySPI {
         }
 
         if (PAMRConfig.PA_PAMRSSH_KNOWN_HOSTS.isSet()) {
-            String knownhost = PAMRConfig.PA_PAMRSSH_KNOWN_HOSTS.getValue();
-            this.config.setKnowHostFile(knownhost);
+            String knownHost = PAMRConfig.PA_PAMRSSH_KNOWN_HOSTS.getValue();
+            this.config.setKnowHostFile(knownHost);
         }
 
         if (PAMRConfig.PA_PAMRSSH_REMOTE_PORT.isSet()) {
@@ -85,6 +85,11 @@ public class PAMRSshSocketFactory implements PAMRSocketFactorySPI {
         if (PAMRConfig.PA_PAMRSSH_REMOTE_USERNAME.isSet()) {
             String username = PAMRConfig.PA_PAMRSSH_REMOTE_USERNAME.getValue();
             this.config.addDefaultHostInformation(SshToken.USERNAME, username);
+        }
+
+        if (PAMRConfig.PA_PAMRSSH_REMOTE_ADDRESS.isSet()) {
+            String sshHost = PAMRConfig.PA_PAMRSSH_REMOTE_ADDRESS.getValue();
+            this.config.addDefaultHostInformation(SshToken.HOSTNAME, sshHost);
         }
 
         this.tp = new SshTunnelPool(this.config);


### PR DESCRIPTION
Support cloud instances for PAMR over SSH

* Fixes the problem where the remote instance is not aware of its public hostname or ip and can't resolve it to its networks interfaces (which is the case in cloud-provided instances or when there's a load-balancer involved)
* Refactor some code to improve readability
* Clarify the sshHost and remoteHost variables
* Applied the coding-rules formatting
* Clean code for readability
* Ignore the intellij out folder
