### PR TITLE
Add public/NATed port support to PNP.

### DIFF
--- a/programming-core/src/test/java/org/objectweb/proactive/core/util/URITest.java
+++ b/programming-core/src/test/java/org/objectweb/proactive/core/util/URITest.java
@@ -42,7 +42,7 @@ public class URITest {
     @Test
     public void checkURI() throws Exception {
         String protocol = "pnp";
-        String userInfo = "machine";
+        String userInfo = "machine:45678";
         String host = "localhost.localdomain";
         String path = "apath";
         String query = "toto=value";
@@ -63,11 +63,11 @@ public class URITest {
 
         // check the remove protocol method
         URI u = URIBuilder.removeProtocol(uri);
-        assertTrue("//machine@localhost.localdomain:1258/apath?toto=value".equals(u.toString()));
+        assertTrue("//machine:45678@localhost.localdomain:1258/apath?toto=value".equals(u.toString()));
 
         // check the remove query method
         u = URIBuilder.removeQuery(uri);
-        assertTrue("pnp://machine@localhost.localdomain:1258/apath".equals(u.toString()));
+        assertTrue("pnp://machine:45678@localhost.localdomain:1258/apath".equals(u.toString()));
 
         // check the setPort method
         int port2 = 5656;
@@ -76,7 +76,7 @@ public class URITest {
 
         // check the setProtocol
         u = URIBuilder.setProtocol(uri, "http");
-        assertTrue("http://machine@localhost.localdomain:1258/apath?toto=value".equals(u.toString()));
+        assertTrue("http://machine:45678@localhost.localdomain:1258/apath?toto=value".equals(u.toString()));
 
         // validate an URI
         try {

--- a/programming-extensions/programming-extension-pnp/src/main/java/org/objectweb/proactive/extensions/pnp/PNPConfig.java
+++ b/programming-extensions/programming-extension-pnp/src/main/java/org/objectweb/proactive/extensions/pnp/PNPConfig.java
@@ -46,6 +46,18 @@ final public class PNPConfig implements PAPropertiesLoaderSPI {
     static final public PAPropertyInteger PA_PNP_PORT = new PAPropertyInteger("proactive.pnp.port", false, 0);
 
     /**
+     * ProActive Runtime Public PNP port
+     * <p/>
+     * This option can be used when a host is behind a NAT. In that case, the original PNP port used by the host is rewritten
+     * by the NAT, and that rewritten port must be advertised to the remote host in order to make PNP communication possible.
+     *
+     * The way for the host behind the NAT to know/predict the new value (i.e. after NAT rewriting) of the PNP port is left out of this scope.
+     */
+    static final public PAPropertyInteger PA_PNP_PUBLIC_PORT = new PAPropertyInteger("proactive.pnp.public_port",
+                                                                                     false,
+                                                                                     -1);
+
+    /**
      * The default heartbeat period (in milliseconds)
      *
      * PNP offers an heartbeat mechanism to detect network failure. If set to 0 heartbeats are disabled and
@@ -106,6 +118,8 @@ final public class PNPConfig implements PAPropertiesLoaderSPI {
 
     private int port;
 
+    private int publicPort;
+
     private int idleTimeout;
 
     private int defaultHeartbeat;
@@ -116,6 +130,7 @@ final public class PNPConfig implements PAPropertiesLoaderSPI {
 
     public PNPConfig() {
         this.port = PA_PNP_PORT.getDefaultValue();
+        this.publicPort = PA_PNP_PUBLIC_PORT.getDefaultValue();
         this.idleTimeout = PA_PNP_IDLE_TIMEOUT.getDefaultValue();
         this.defaultHeartbeat = PA_PNP_DEFAULT_HEARTBEAT.getDefaultValue();
         this.heartbeatFactor = PA_PNP_HEARTBEAT_FACTOR.getDefaultValue();
@@ -124,6 +139,10 @@ final public class PNPConfig implements PAPropertiesLoaderSPI {
 
     public void setPort(int port) {
         this.port = port;
+    }
+
+    public void setPublicPort(int publicPort) {
+        this.publicPort = publicPort;
     }
 
     public void setIdleTimeout(int idleTimeout) {
@@ -152,6 +171,10 @@ final public class PNPConfig implements PAPropertiesLoaderSPI {
 
     public int getPort() {
         return port;
+    }
+
+    public int getPublicPort() {
+        return publicPort;
     }
 
     public int getIdleTimeout() {

--- a/programming-extensions/programming-extension-pnp/src/main/java/org/objectweb/proactive/extensions/pnp/PNPRemoteObjectFactory.java
+++ b/programming-extensions/programming-extension-pnp/src/main/java/org/objectweb/proactive/extensions/pnp/PNPRemoteObjectFactory.java
@@ -37,6 +37,7 @@ public class PNPRemoteObjectFactory extends PNPRemoteObjectFactoryAbstract {
 
         PNPConfig config = new PNPConfig();
         config.setPort(PNPConfig.PA_PNP_PORT.getValue());
+        config.setPublicPort(PNPConfig.PA_PNP_PUBLIC_PORT.getValue());
         config.setIdleTimeout(PNPConfig.PA_PNP_IDLE_TIMEOUT.getValue());
         config.setDefaultHeartbeat(PNPConfig.PA_PNP_DEFAULT_HEARTBEAT.getValue());
         config.setHeartbeatFactor(PNPConfig.PA_PNP_HEARTBEAT_FACTOR.getValue());

--- a/programming-extensions/programming-extension-pnp/src/main/java/org/objectweb/proactive/extensions/pnp/PNPRemoteObjectFactoryBackend.java
+++ b/programming-extensions/programming-extension-pnp/src/main/java/org/objectweb/proactive/extensions/pnp/PNPRemoteObjectFactoryBackend.java
@@ -67,7 +67,7 @@ public class PNPRemoteObjectFactoryBackend extends AbstractRemoteObjectFactory i
 
     final private PNPRegistry registry;
 
-    final private int PNPPublicPort;
+    final private int pnpPublicPort;
 
     /** Exception that should have been thrown by ctor.
      *
@@ -89,7 +89,7 @@ public class PNPRemoteObjectFactoryBackend extends AbstractRemoteObjectFactory i
         this.ctorException = exception;
         this.registry = PNPRegistry.singleton;
         this.protoId = proto;
-        this.PNPPublicPort = config.getPublicPort();
+        this.pnpPublicPort = config.getPublicPort();
     }
 
     private void throwIfAgentIsNul(String msg) throws ProActiveException {
@@ -210,12 +210,13 @@ public class PNPRemoteObjectFactoryBackend extends AbstractRemoteObjectFactory i
             // Retrieve if specified the PNP(S) public address and  public port,
             // and embed this information inside the 'user info' URI field (RFC 2396)
             // Note: if no public address is provided, we do not use public port
-            String publicAddress = ProActiveInet.getPublicAddress(), uriUserInfo;
+            String publicAddress = ProActiveInet.getPublicAddress(), uriUserInfo = null;
             if (publicAddress != null) {
-                uriUserInfo = (PNPPublicPort != -1) ? ProActiveInet.getPublicAddress() + ':' + PNPPublicPort
-                                                    : ProActiveInet.getPublicAddress();
-            } else
-                uriUserInfo = null;
+                if (pnpPublicPort != -1) {
+                    uriUserInfo = ProActiveInet.getPublicAddress() + ':' + pnpPublicPort;
+                } else
+                    uriUserInfo = ProActiveInet.getPublicAddress();
+            }
 
             // the URI is constructed with a userinfo parameter if the property proactive.net.public_address is enabled
             // in that case, the PNP remote object will have a uri such as pnp://public_address@host:port/name
@@ -260,7 +261,7 @@ public class PNPRemoteObjectFactoryBackend extends AbstractRemoteObjectFactory i
         String publicAddress = ProActiveInet.getPublicAddress();
         // Note: if no public address is provided, we do not use public port
         if (publicAddress != null) {
-            return (PNPPublicPort != -1) ? ProActiveInet.getPublicAddress() + ':' + PNPPublicPort + '@'
+            return (pnpPublicPort != -1) ? ProActiveInet.getPublicAddress() + ':' + pnpPublicPort + '@'
                                          : ProActiveInet.getPublicAddress() + '@';
         } else
             return "";

--- a/programming-extensions/programming-extension-pnpssl/src/main/java/org/objectweb/proactive/extensions/pnpssl/PNPSslConfig.java
+++ b/programming-extensions/programming-extension-pnpssl/src/main/java/org/objectweb/proactive/extensions/pnpssl/PNPSslConfig.java
@@ -52,6 +52,18 @@ final public class PNPSslConfig implements PAPropertiesLoaderSPI {
     static final public PAPropertyInteger PA_PNPSSL_PORT = new PAPropertyInteger("proactive.pnps.port", false, 0);
 
     /**
+     * ProActive Runtime Public PNP port
+     * <p/>
+     * This option can be used when a host is behind a NAT. In that case, the original PNP port used by the host is rewritten
+     * by the NAT, and that rewritten port must be advertised to the remote host in order to make PNP communication possible.
+     *
+     * The way for the host behind the NAT to know/predict the new value (i.e. after NAT rewriting) of the PNP port is left out of this scope.
+     */
+    static final public PAPropertyInteger PA_PNPSSL_PUBLIC_PORT = new PAPropertyInteger("proactive.pnps.public_port",
+                                                                                        false,
+                                                                                        -1);
+
+    /**
      * The default heartbeat period (in milliseconds)
      * <p>
      * PNP offers an heartbeat mechanism to detect network failure. If set to 0 hearthbeats are disabled and

--- a/programming-extensions/programming-extension-pnpssl/src/main/java/org/objectweb/proactive/extensions/pnpssl/PNPSslRemoteObjectFactory.java
+++ b/programming-extensions/programming-extension-pnpssl/src/main/java/org/objectweb/proactive/extensions/pnpssl/PNPSslRemoteObjectFactory.java
@@ -72,6 +72,7 @@ public class PNPSslRemoteObjectFactory extends PNPRemoteObjectFactoryAbstract {
         // Handle standard pnp options
         PNPConfig config = new PNPConfig();
         config.setPort(PNPSslConfig.PA_PNPSSL_PORT.getValue());
+        config.setPublicPort(PNPSslConfig.PA_PNPSSL_PUBLIC_PORT.getValue());
         config.setIdleTimeout(PNPSslConfig.PA_PNPSSL_IDLE_TIMEOUT.getValue());
         config.setDefaultHeartbeat(PNPSslConfig.PA_PNPSSL_DEFAULT_HEARTBEAT.getValue());
         config.setHeartbeatFactor(PNPSslConfig.PA_PNPSSL_HEARTBEAT_FACTOR.getValue());

--- a/programming-test/src/test/java/functionalTests/pnp/TestPNPPublicPort.java
+++ b/programming-test/src/test/java/functionalTests/pnp/TestPNPPublicPort.java
@@ -1,0 +1,72 @@
+/*
+ * ProActive Parallel Suite(TM):
+ * The Open Source library for parallel and distributed
+ * Workflows & Scheduling, Orchestration, Cloud Automation
+ * and Big Data Analysis on Enterprise Grids & Clouds.
+ *
+ * Copyright (c) 2007 - 2017 ActiveEon
+ * Contact: contact@activeeon.com
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation: version 3 of
+ * the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ */
+package functionalTests.pnp;
+
+import java.net.InetAddress;
+
+import org.apache.log4j.BasicConfigurator;
+import org.junit.Assert;
+import org.junit.Test;
+import org.objectweb.proactive.api.PAActiveObject;
+import org.objectweb.proactive.core.config.CentralPAPropertyRepository;
+import org.objectweb.proactive.core.util.wrapper.BooleanWrapper;
+import org.objectweb.proactive.extensions.pnp.PNPConfig;
+
+import functionalTests.FunctionalTest;
+
+
+public class TestPNPPublicPort extends FunctionalTest {
+    @Test
+    public void testPNPNewActivePublicAddress() throws Exception {
+        final int mockPublicPort = 45678;
+        BasicConfigurator.resetConfiguration();
+        BasicConfigurator.configure();
+        CentralPAPropertyRepository.PA_COMMUNICATION_PROTOCOL.setValue("pnp");
+        CentralPAPropertyRepository.PA_PUBLIC_ADDRESS.setValue(InetAddress.getLocalHost().getHostName());
+        PNPConfig.PA_PNP_PUBLIC_PORT.setValue(mockPublicPort);
+        AOTest ao = PAActiveObject.newActive(AOTest.class, new Object[0]);
+
+        String aoUrl = PAActiveObject.getUrl(ao);
+        Assert.assertTrue(aoUrl + " should contain public address and public port inside user info",
+                          aoUrl.startsWith("pnp://" + InetAddress.getLocalHost().getHostName() + ':' + mockPublicPort +
+                                           "@"));
+
+        ao.sayHello().getBooleanValue();
+
+        AOTest ao2 = PAActiveObject.lookupActive(AOTest.class, aoUrl);
+        ao2.sayHello().getBooleanValue();
+    }
+
+    public static class AOTest {
+        public AOTest() {
+
+        }
+
+        BooleanWrapper sayHello() {
+            return new BooleanWrapper(true);
+        }
+    }
+}


### PR DESCRIPTION
- Add proactive.pnp.public_port setting. It allows to specify a
  public/NATed port which can be used to contact the Remote
  Objects directly.
- proactive.pnp.public_port is taken into account only if
  proactive.net.public_address is also specified.
- To contact a Remote Object which contains a public address and a
  public port, the pnp protocol tries first to open a socket to the
  private address and private port, and if the connection fails, it will
  create a socket to the public address on the public port.
- To contact a Remote Object which contains a public address but no
  public port, the pnp protocol tries first to open a socket to the
  private address, and if the connection fails, it will create a socket
  to the public address with the private port.

Note:
- By private port we mean the actual PNP port open by the Remote
Object.
- By public port we mean the port reachable from outside the Remote
  Object (typically when the Remote Object is behind a NAT).