### PR TITLE
Source $HOME/.bashrc from the impersonated process

### DIFF
--- a/programming-extensions/programming-extension-processbuilder/src/main/resources/processbuilder/linux/command_step.sh
+++ b/programming-extensions/programming-extension-processbuilder/src/main/resources/processbuilder/linux/command_step.sh
@@ -79,8 +79,12 @@ fi;
 
 if [ -e "$cmd_path" ]; then
   if [ -x "$cmd_path" ]; then
+    # load the user default environment
+    if [ -f "$HOME/.bashrc" ]; then
+        source "$HOME/.bashrc"
+    fi
 
-    # load the environment variables
+    # load the custom environment variables
     set -a
     source $tmpenv
     rm $tmpenv 2> /dev/null


### PR DESCRIPTION
Without this the impersonated process does not load automatically the user .bashrc file if defined (su and ssh does not load automatically the environment in this context).