### PR TITLE
Manually fix the serialver to exclude last digit of ProActive version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 #Tue, 18 Sep 2018 13:12:45 +0200
 programmingVersion=8.4.0-SNAPSHOT
-programmingSerialver=840L
+programmingSerialver=84L


### PR DESCRIPTION
- The release process mistakenly included the maintenance version in the serial version UIDs. We fix this by applying manually the correct serial version UID for the next local builds. The automated version increase process is fixed separately for the future releases.