### PR TITLE
Add fixed serial uid to classes serialized inside the Node structure

### DIFF
--- a/programming-core/src/main/java/org/objectweb/proactive/core/node/NodeImpl.java
+++ b/programming-core/src/main/java/org/objectweb/proactive/core/node/NodeImpl.java
@@ -237,6 +237,8 @@ public class NodeImpl implements Node, Serializable {
     //
     protected class NodeInformationImpl implements NodeInformation {
 
+        private static final long serialVersionUID = 1L;
+
         final private String nodeName;
 
         final private String nodeURL;

--- a/programming-core/src/main/java/org/objectweb/proactive/core/remoteobject/InternalRemoteRemoteObjectImpl.java
+++ b/programming-core/src/main/java/org/objectweb/proactive/core/remoteobject/InternalRemoteRemoteObjectImpl.java
@@ -49,6 +49,8 @@ import org.objectweb.proactive.core.mop.MethodCallExecutionFailedException;
  */
 public class InternalRemoteRemoteObjectImpl implements InternalRemoteRemoteObject {
 
+    private static final long serialVersionUID = 1L;
+
     /**
      * the remote remote object of the internal remote remote object.
      * Remote method calls are received by this remote remote object,

--- a/programming-core/src/main/java/org/objectweb/proactive/core/remoteobject/RemoteObjectAdapter.java
+++ b/programming-core/src/main/java/org/objectweb/proactive/core/remoteobject/RemoteObjectAdapter.java
@@ -54,6 +54,9 @@ import org.objectweb.proactive.core.util.log.ProActiveLogger;
  *         that the remote object called is distant.
  */
 public class RemoteObjectAdapter implements RemoteObject, Serializable {
+
+    private static final long serialVersionUID = 1L;
+
     static final Logger LOGGER_RO = ProActiveLogger.getLogger(Loggers.REMOTEOBJECT);
 
     static final String UNKNOWN = "[unknown]";

--- a/programming-core/src/main/java/org/objectweb/proactive/core/remoteobject/RemoteObjectSet.java
+++ b/programming-core/src/main/java/org/objectweb/proactive/core/remoteobject/RemoteObjectSet.java
@@ -68,6 +68,8 @@ import org.objectweb.proactive.core.util.log.ProActiveLogger;
 
 public class RemoteObjectSet implements Serializable, Observer {
 
+    private static final long serialVersionUID = 1L;
+
     static final Logger LOGGER_RO = ProActiveLogger.getLogger(Loggers.REMOTEOBJECT);
 
     public static final int UNREACHABLE_VALUE = Integer.MIN_VALUE;

--- a/programming-core/src/main/java/org/objectweb/proactive/core/remoteobject/RemoteRemoteObject.java
+++ b/programming-core/src/main/java/org/objectweb/proactive/core/remoteobject/RemoteRemoteObject.java
@@ -47,6 +47,10 @@ import org.objectweb.proactive.core.body.request.Request;
  */
 public interface RemoteRemoteObject extends Serializable {
 
+    // this field declaration is used to force stubs generated from this interface
+    // to contain a fixed serialuid
+    static final long serialVersionUID = 1L;
+
     /**
      * Send a message containing a reified method call to a remote object. the target of the message
      * could be either the reified object or the remote object itself

--- a/programming-core/src/main/java/org/objectweb/proactive/core/remoteobject/SynchronousProxy.java
+++ b/programming-core/src/main/java/org/objectweb/proactive/core/remoteobject/SynchronousProxy.java
@@ -47,6 +47,9 @@ import org.objectweb.proactive.core.mop.Proxy;
  *  @author The ProActive Team
  */
 public class SynchronousProxy implements Proxy, Serializable {
+
+    private static final long serialVersionUID = 1L;
+
     protected RemoteObject remoteObject;
 
     public SynchronousProxy(ConstructorCall contructorCall, Object[] params) throws ProActiveException {

--- a/programming-core/src/main/java/org/objectweb/proactive/core/remoteobject/adapter/Adapter.java
+++ b/programming-core/src/main/java/org/objectweb/proactive/core/remoteobject/adapter/Adapter.java
@@ -40,6 +40,8 @@ import org.objectweb.proactive.core.mop.StubObject;
 
 public abstract class Adapter<T> implements Serializable, StubObject, Cloneable {
 
+    private static final long serialVersionUID = 1L;
+
     /**
      * the generated stub
      */

--- a/programming-core/src/main/java/org/objectweb/proactive/core/remoteobject/http/HttpRemoteObjectImpl.java
+++ b/programming-core/src/main/java/org/objectweb/proactive/core/remoteobject/http/HttpRemoteObjectImpl.java
@@ -37,6 +37,9 @@ import org.objectweb.proactive.core.remoteobject.http.message.HTTPRemoteObjectRe
 
 
 public class HttpRemoteObjectImpl implements HTTPRemoteObject {
+
+    private static final long serialVersionUID = 1L;
+
     private boolean isLocal;
 
     private URI remoteObjectURL;

--- a/programming-core/src/main/java/org/objectweb/proactive/core/remoteobject/rmi/RmiRemoteObjectImpl.java
+++ b/programming-core/src/main/java/org/objectweb/proactive/core/remoteobject/rmi/RmiRemoteObjectImpl.java
@@ -45,6 +45,9 @@ import org.objectweb.proactive.core.remoteobject.InternalRemoteRemoteObject;
  */
 
 public class RmiRemoteObjectImpl extends UnicastRemoteObject implements RmiRemoteObject {
+
+    private static final long serialVersionUID = 1L;
+
     protected InternalRemoteRemoteObject internalrrObject;
 
     public RmiRemoteObjectImpl() throws java.rmi.RemoteException {

--- a/programming-core/src/main/java/org/objectweb/proactive/core/remoteobject/rmissh/RmiSshRemoteObjectImpl.java
+++ b/programming-core/src/main/java/org/objectweb/proactive/core/remoteobject/rmissh/RmiSshRemoteObjectImpl.java
@@ -33,6 +33,8 @@ import org.objectweb.proactive.core.remoteobject.rmi.RmiRemoteObjectImpl;
 
 public class RmiSshRemoteObjectImpl extends RmiRemoteObjectImpl {
 
+    private static final long serialVersionUID = 1L;
+
     public RmiSshRemoteObjectImpl(InternalRemoteRemoteObject target) throws java.rmi.RemoteException {
         super(target, RMISocketFactory.getDefaultSocketFactory(), RmiSshRemoteObjectFactory.sf);
     }

--- a/programming-core/src/main/java/org/objectweb/proactive/core/runtime/ProActiveRuntime.java
+++ b/programming-core/src/main/java/org/objectweb/proactive/core/runtime/ProActiveRuntime.java
@@ -73,6 +73,11 @@ import org.objectweb.proactive.core.util.log.ProActiveLogger;
  *
  */
 public interface ProActiveRuntime {
+
+    // this field declaration is used to force stubs generated from this interface
+    // to contain a fixed serialuid
+    static final long serialVersionUID = 1L;
+
     static Logger runtimeLogger = ProActiveLogger.getLogger(Loggers.RUNTIME);
 
     /**

--- a/programming-core/src/main/java/org/objectweb/proactive/core/runtime/ProActiveRuntimeImpl.java
+++ b/programming-core/src/main/java/org/objectweb/proactive/core/runtime/ProActiveRuntimeImpl.java
@@ -1018,6 +1018,9 @@ public class ProActiveRuntimeImpl extends RuntimeRegistrationEventProducerImpl
     // -- INNER CLASSES -----------------------------------------------
     //
     protected static class VMInformationImpl implements VMInformation, java.io.Serializable {
+
+        private static final long serialVersionUID = 1L;
+
         private final java.net.InetAddress hostInetAddress;
 
         // the Unique ID of the JVM

--- a/programming-core/src/main/java/org/objectweb/proactive/core/runtime/ProActiveRuntimeRemoteObjectAdapter.java
+++ b/programming-core/src/main/java/org/objectweb/proactive/core/runtime/ProActiveRuntimeRemoteObjectAdapter.java
@@ -56,6 +56,8 @@ import org.objectweb.proactive.core.remoteobject.adapter.Adapter;
 
 public class ProActiveRuntimeRemoteObjectAdapter extends Adapter<ProActiveRuntime> implements ProActiveRuntime {
 
+    private static final long serialVersionUID = 1L;
+
     /**
      * generated serial uid
      */

--- a/programming-extensions/programming-extension-amqp/src/main/java/org/objectweb/proactive/extensions/amqp/federation/AMQPFederationRemoteObject.java
+++ b/programming-extensions/programming-extension-amqp/src/main/java/org/objectweb/proactive/extensions/amqp/federation/AMQPFederationRemoteObject.java
@@ -51,6 +51,8 @@ import org.objectweb.proactive.extensions.amqp.remoteobject.RpcReusableChannel;
  */
 public class AMQPFederationRemoteObject extends AbstractAMQPRemoteObject {
 
+    private static final long serialVersionUID = 1L;
+
     private static final String RPC_EXCHANGE_NAME = AMQPFederationConfig.PA_AMQP_FEDERATION_RPC_EXCHANGE_NAME.getValue();
 
     private static final long RPC_REPLY_TIMEOUT = AMQPFederationConfig.PA_AMQP_FEDERATION_RPC_TIMEOUT.getValue();

--- a/programming-extensions/programming-extension-amqp/src/main/java/org/objectweb/proactive/extensions/amqp/remoteobject/AMQPRemoteObject.java
+++ b/programming-extensions/programming-extension-amqp/src/main/java/org/objectweb/proactive/extensions/amqp/remoteobject/AMQPRemoteObject.java
@@ -48,6 +48,8 @@ import org.objectweb.proactive.extensions.amqp.AMQPConfig;
  */
 public class AMQPRemoteObject extends AbstractAMQPRemoteObject {
 
+    private static final long serialVersionUID = 1L;
+
     private static final String RPC_EXCHANGE_NAME = AMQPConfig.PA_AMQP_RPC_EXCHANGE_NAME.getValue();
 
     private static final long RPC_REPLY_TIMEOUT = AMQPConfig.PA_AMQP_RPC_TIMEOUT.getValue();

--- a/programming-extensions/programming-extension-amqp/src/main/java/org/objectweb/proactive/extensions/amqp/remoteobject/AbstractAMQPRemoteObject.java
+++ b/programming-extensions/programming-extension-amqp/src/main/java/org/objectweb/proactive/extensions/amqp/remoteobject/AbstractAMQPRemoteObject.java
@@ -69,6 +69,9 @@ import com.rabbitmq.client.QueueingConsumer.Delivery;
  *
  */
 public abstract class AbstractAMQPRemoteObject implements RemoteRemoteObject, Serializable {
+
+    private static final long serialVersionUID = 1L;
+
     final static private Logger logger = ProActiveLogger.getLogger(AMQPConfig.Loggers.AMQP_REMOTE_OBJECT);
 
     private final String rpcExchangeName;

--- a/programming-extensions/programming-extension-pamr/src/main/java/org/objectweb/proactive/extensions/pamr/remoteobject/PAMRRemoteObject.java
+++ b/programming-extensions/programming-extension-pamr/src/main/java/org/objectweb/proactive/extensions/pamr/remoteobject/PAMRRemoteObject.java
@@ -49,6 +49,9 @@ import org.objectweb.proactive.extensions.pamr.remoteobject.message.PAMRRemoteOb
  */
 
 public class PAMRRemoteObject implements RemoteRemoteObject, Serializable {
+
+    private static final long serialVersionUID = 1L;
+
     final static private Logger logger = ProActiveLogger.getLogger(PAMRConfig.Loggers.PAMR_REMOTE_OBJECT);
 
     /** The URL of the RemoteObject */

--- a/programming-extensions/programming-extension-pnp/src/main/java/org/objectweb/proactive/extensions/pnp/PNPRemoteObject.java
+++ b/programming-extensions/programming-extension-pnp/src/main/java/org/objectweb/proactive/extensions/pnp/PNPRemoteObject.java
@@ -45,6 +45,9 @@ import org.objectweb.proactive.core.util.log.ProActiveLogger;
  * @since ProActive 4.3.0
  */
 class PNPRemoteObject implements RemoteRemoteObject, Serializable {
+
+    private static final long serialVersionUID = 1L;
+
     final static private Logger logger = ProActiveLogger.getLogger(PNPConfig.Loggers.PNP);
 
     /** The URL of the RemoteObject */


### PR DESCRIPTION
The Node structure contains references to many objects which are serialized within it. This change is to force a fixed serialuid on those classes (which change extremely rarely).