### PR TITLE
Improve FutureMonitoring

### DIFF
--- a/programming-core/src/main/java/org/objectweb/proactive/core/body/proxy/AbstractBodyProxy.java
+++ b/programming-core/src/main/java/org/objectweb/proactive/core/body/proxy/AbstractBodyProxy.java
@@ -279,6 +279,7 @@ public abstract class AbstractBodyProxy extends AbstractProxy implements BodyPro
         // Set the id of the body creator in the created future
         FutureProxy fp = (FutureProxy) (futureobject.getProxy());
         fp.setCreatorID(this.getBodyID());
+        fp.setCreator(this.getBody());
         fp.setUpdater(this.getBody());
         fp.setOriginatingProxy(this);
         Method m = methodCall.getReifiedMethod();
@@ -306,6 +307,7 @@ public abstract class AbstractBodyProxy extends AbstractProxy implements BodyPro
         // Setting methodCall.res to null means that we do not use the future mechanism
         FutureProxy fp = FutureProxy.getFutureProxy();
         fp.setCreatorID(this.getBodyID());
+        fp.setCreator(this.getBody());
         fp.setUpdater(this.getBody());
         Method m = methodCall.getReifiedMethod();
         fp.setCreatorStackTraceElement(new StackTraceElement(m.getDeclaringClass().getName(),

--- a/programming-core/src/main/java/org/objectweb/proactive/core/runtime/ProActiveRuntimeImpl.java
+++ b/programming-core/src/main/java/org/objectweb/proactive/core/runtime/ProActiveRuntimeImpl.java
@@ -832,6 +832,7 @@ public class ProActiveRuntimeImpl extends RuntimeRegistrationEventProducerImpl
      * @inheritDoc
      */
     @Override
+    @SuppressWarnings("unchecked")
     public List<UniversalBody> getActiveObjects(String nodeName, String className) {
         // the array to return
 

--- a/programming-core/src/main/java/org/objectweb/proactive/core/util/ProActiveInet.java
+++ b/programming-core/src/main/java/org/objectweb/proactive/core/util/ProActiveInet.java
@@ -421,7 +421,7 @@ public class ProActiveInet {
                         // try to connect to *somewhere*
                         socket.connect(new InetSocketAddress(InetAddress.getByName(serverToConnectTo), port));
                         long end = System.currentTimeMillis();
-                        return new AbstractMap.SimpleImmutableEntry(address, (int) (end - start));
+                        return new AbstractMap.SimpleImmutableEntry<>(address, (int) (end - start));
                     }
                 }
             });

--- a/programming-test/src/test/java/functionalTests/activeobject/futuremonitoring/iservice/AOProxy.java
+++ b/programming-test/src/test/java/functionalTests/activeobject/futuremonitoring/iservice/AOProxy.java
@@ -1,0 +1,54 @@
+/*
+ * ProActive Parallel Suite(TM):
+ * The Open Source library for parallel and distributed
+ * Workflows & Scheduling, Orchestration, Cloud Automation
+ * and Big Data Analysis on Enterprise Grids & Clouds.
+ *
+ * Copyright (c) 2007 - 2017 ActiveEon
+ * Contact: contact@activeeon.com
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation: version 3 of
+ * the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ */
+package functionalTests.activeobject.futuremonitoring.iservice;
+
+import java.io.Serializable;
+
+import org.objectweb.proactive.annotation.ImmediateService;
+import org.objectweb.proactive.core.util.wrapper.BooleanWrapper;
+
+
+/**
+ * @author ActiveEon Team
+ * @since 22/10/2019
+ */
+public class AOProxy implements Serializable {
+
+    private AOServer server;
+
+    public AOProxy() {
+
+    }
+
+    public AOProxy(AOServer server) {
+        this.server = server;
+    }
+
+    @ImmediateService
+    public BooleanWrapper forwardFuture() {
+        return server.asyncRequest();
+    }
+}

--- a/programming-test/src/test/java/functionalTests/activeobject/futuremonitoring/iservice/AOServer.java
+++ b/programming-test/src/test/java/functionalTests/activeobject/futuremonitoring/iservice/AOServer.java
@@ -1,0 +1,52 @@
+/*
+ * ProActive Parallel Suite(TM):
+ * The Open Source library for parallel and distributed
+ * Workflows & Scheduling, Orchestration, Cloud Automation
+ * and Big Data Analysis on Enterprise Grids & Clouds.
+ *
+ * Copyright (c) 2007 - 2017 ActiveEon
+ * Contact: contact@activeeon.com
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation: version 3 of
+ * the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ */
+package functionalTests.activeobject.futuremonitoring.iservice;
+
+import org.objectweb.proactive.core.util.wrapper.BooleanWrapper;
+
+
+/**
+ * @author ActiveEon Team
+ * @since 22/10/2019
+ */
+public class AOServer implements java.io.Serializable {
+
+    public AOServer() {
+
+    }
+
+    public BooleanWrapper asyncRequest() {
+
+        for (int i = 0; i < 1000; i++) {
+            try {
+                Thread.sleep(500000);
+            } catch (InterruptedException e) {
+
+            }
+        }
+        return new BooleanWrapper(true);
+    }
+}

--- a/programming-test/src/test/java/functionalTests/activeobject/futuremonitoring/iservice/TestFutureMonitoringWithProxy.java
+++ b/programming-test/src/test/java/functionalTests/activeobject/futuremonitoring/iservice/TestFutureMonitoringWithProxy.java
@@ -1,0 +1,72 @@
+/*
+ * ProActive Parallel Suite(TM):
+ * The Open Source library for parallel and distributed
+ * Workflows & Scheduling, Orchestration, Cloud Automation
+ * and Big Data Analysis on Enterprise Grids & Clouds.
+ *
+ * Copyright (c) 2007 - 2017 ActiveEon
+ * Contact: contact@activeeon.com
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation: version 3 of
+ * the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ */
+package functionalTests.activeobject.futuremonitoring.iservice;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.objectweb.proactive.api.PAActiveObject;
+import org.objectweb.proactive.api.PAFuture;
+import org.objectweb.proactive.core.ProActiveException;
+import org.objectweb.proactive.core.body.exceptions.FutureMonitoringPingFailureException;
+import org.objectweb.proactive.core.node.Node;
+import org.objectweb.proactive.core.util.wrapper.BooleanWrapper;
+
+import functionalTests.GCMFunctionalTest;
+
+
+/**
+ * Scenario with two active objects.
+ * First one, the server returns a future asynchronously (and takes forever to return the value)
+ * Second one, the proxy forwards this future to the caller, via an immediate service.
+ * This test checks that when the server is destroyed, the client receives an exception and does not block forever.
+ * @author ActiveEon Team
+ * @since 22/10/2019
+ */
+public class TestFutureMonitoringWithProxy extends GCMFunctionalTest {
+
+    public TestFutureMonitoringWithProxy() throws ProActiveException {
+        super(1, 1);
+        super.startDeployment();
+    }
+
+    @Test(expected = FutureMonitoringPingFailureException.class)
+    public void action() throws Throwable {
+        Node node = super.getANode();
+        // create the server on the remote node
+        AOServer server = PAActiveObject.newActive(AOServer.class, new Object[0], node);
+        // create the proxy locally
+        AOProxy proxy = PAActiveObject.newActive(AOProxy.class, new Object[] { server });
+        // Future asynchronous call
+        BooleanWrapper future = proxy.forwardFuture();
+        // Kill the remote node
+        try {
+            node.getProActiveRuntime().killRT(false);
+        } catch (Exception e) {
+
+        }
+        Assert.assertFalse("Result should not be true", PAFuture.getFutureValue(future).getBooleanValue());
+    }
+}


### PR DESCRIPTION
 - in the scenario where a future is forwarded between active objects, it is necessary to monitor the original active object in the forward chain. Otherwise, the future consumer may block forever if the originator active object dies.
 - to fix this issue, add the creator reference (first active object in the chain) to FutureProxy and use this reference, along with the updater (last active object in the chain) inside FutureMonitoring
  - changed the default monitoring cycle in FutureMonitoring
  - created a functional test