### PR TITLE
OSSindex integration + Security updates

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,7 @@ allprojects {
     apply plugin: 'eclipse'
     apply plugin: 'project-report'
     apply plugin: 'com.github.jk1.dependency-license-report'
+    apply plugin: "net.ossindex.audit"
 }
 
 buildscript {
@@ -27,7 +28,8 @@ buildscript {
         classpath 'org.ow2.proactive:gradle-serialver:2.2'
         classpath "com.diffplug.gradle.spotless:spotless:2.4.0"
         classpath "org.ow2.proactive:coding-rules:1.0.0"
-    classpath 'com.github.jk1:gradle-license-report:1.7'
+        classpath 'com.github.jk1:gradle-license-report:1.7'
+        classpath "gradle.plugin.net.ossindex:ossindex-gradle-plugin:0.4.11"
         delete "gradle/ext"
         ant.unjar src: configurations.classpath.find { it.name.startsWith("coding-rules") }, dest: 'gradle/ext'
     }

--- a/build.gradle
+++ b/build.gradle
@@ -356,7 +356,7 @@ project('programming-extensions:programming-extension-pnp') {
                 project(':programming-core'),
                 'io.netty:netty:3.10.6.Final',
                 'com.google.guava:guava:19.0',
-                'org.apache.commons:commons-collections4:4.0'
+                'org.apache.commons:commons-collections4:4.4'
         )
     }
 }
@@ -366,7 +366,7 @@ project('programming-extensions:programming-extension-pnpssl') {
         compile(
                 project(':programming-core'),
                 'io.netty:netty:3.10.6.Final',
-                'org.bouncycastle:bcprov-ext-jdk15on:1.52',
+                'org.bouncycastle:bcprov-ext-jdk15on:1.64',
 
                 project(':programming-extensions:programming-extension-pnp')
         )

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ buildscript {
             url "https://plugins.gradle.org/m2/"
         }
         maven { url 'http://repository.activeeon.com/content/groups/proactive/'}
-
+        
     }
 
     dependencies {
@@ -256,8 +256,8 @@ def vfs2CompileDependencies = ['org.apache.commons:commons-vfs2:2.1.1744488.1']
 def vfs2RuntimeDependencies = [
         'commons-net:commons-net:3.5',
         'commons-httpclient:commons-httpclient:3.1',
-        'com.jcraft:jsch:0.1.53',
-        'org.apache.jackrabbit:jackrabbit-webdav:1.5.2',
+        'com.jcraft:jsch:0.1.55',
+        'org.apache.jackrabbit:jackrabbit-webdav:1.5.5',
         'org.slf4j:slf4j-api:1.7.12']
 
 project('programming-extensions:programming-extension-dataspaces-common') {
@@ -284,7 +284,7 @@ project('programming-extensions:programming-extension-vfsprovider') {
             exclude group: 'com.fasterxml.jackson.core'
             exclude group: 'com.fasterxml.jackson.dataformat'
         }
-        compile 'com.fasterxml.jackson.core:jackson-databind:2.7.9'
+        compile 'com.fasterxml.jackson.core:jackson-databind:2.7.9.6'
         compile 'com.fasterxml.jackson.core:jackson-core:2.7.9'
         compile 'com.fasterxml.jackson.core:jackson-annotations:2.7.9'
         compile 'com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.7.9'

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ buildscript {
             url "https://plugins.gradle.org/m2/"
         }
         maven { url 'http://repository.activeeon.com/content/groups/proactive/'}
-        
+
     }
 
     dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,10 @@ buildscript {
 
 ext.serialver = programmingSerialver
 
+audit {
+    failOnError = false
+}
+
 subprojects {
     apply plugin: 'java'
     apply plugin: 'maven'
@@ -159,9 +163,9 @@ project(':programming-core') {
 
     dependencies {
         compile(
-                'org.eclipse.jetty:jetty-server:9.2.14.v20151106',
-                'org.eclipse.jetty:jetty-servlet:9.2.14.v20151106',
-                'org.eclipse.jetty:jetty-xml:9.2.14.v20151106',
+                'org.eclipse.jetty:jetty-server:9.2.29.v20191105',
+                'org.eclipse.jetty:jetty-servlet:9.2.29.v20191105',
+                'org.eclipse.jetty:jetty-xml:9.2.29.v20191105',
 
                 'org.tmatesoft.svnkit:trilead-ssh2:build213-svnkit-1.3-patch',
 

--- a/build.gradle
+++ b/build.gradle
@@ -54,7 +54,7 @@ subprojects {
     audit {
          failOnError = false
          rateLimitAsError = false
-         cache = "/tmp/ossindex.cache"
+         cache = System.getProperty("java.io.tmpdir") +"/ossindex.cache"
     }
     compileJava.dependsOn 'audit'
 

--- a/build.gradle
+++ b/build.gradle
@@ -37,10 +37,6 @@ buildscript {
 
 ext.serialver = programmingSerialver
 
-audit {
-    failOnError = false
-}
-
 subprojects {
     apply plugin: 'java'
     apply plugin: 'maven'
@@ -53,6 +49,14 @@ subprojects {
     targetCompatibility = JavaVersion.VERSION_1_7
 
     compileJava.options.compilerArgs << '-Xlint:-options' // remove warning about bootstrap class path
+
+
+    audit {
+         failOnError = false
+         rateLimitAsError = false
+         cache = "/tmp/ossindex.cache"
+    }
+    compileJava.dependsOn 'audit'
 
     rootProject.buildscript.repositories.each {
         repositories.add(it)
@@ -515,7 +519,6 @@ project(':doc').subprojects {
 }
 
 apply from: 'dist.gradle'
-
 
 licenseReport {
     configurations = ['runtime']

--- a/build.gradle
+++ b/build.gradle
@@ -54,7 +54,7 @@ subprojects {
     audit {
          failOnError = false
          rateLimitAsError = false
-         cache = System.getProperty("java.io.tmpdir") +"/ossindex.cache"
+         cache = System.getProperty("java.io.tmpdir") + "ossindex.cache"
     }
     compileJava.dependsOn 'audit'
 


### PR DESCRIPTION
In this PR, we (i) integrate the oss-audit to determine CVE flawing the code of the projet and (ii) update the dependencies identified as vulnerable to their latest maintenance versions.

A contributor can now inspect the project to assess if security updates have to be enforced by executing `./gradlew audit [--info]`.