### PR TITLE
Allow agent reconnection after router restart

### DIFF
--- a/programming-extensions/programming-extension-pamr/src/main/java/org/objectweb/proactive/extensions/pamr/client/AgentImpl.java
+++ b/programming-extensions/programming-extension-pamr/src/main/java/org/objectweb/proactive/extensions/pamr/client/AgentImpl.java
@@ -182,7 +182,7 @@ public class AgentImpl implements Agent, AgentImplMBean {
         this.socketFactory = socketFactory;
         this.agentID = agentId; // Check the agentId number
         this.magicCookie = magicCookie;
-        this.routerID = RouterImpl.DEFAULT_ROUTER_ID;
+        this.routerID = RouterImpl.UNKNOWN_ROUTER_ID;
 
         try {
             Constructor<? extends MessageHandler> mhConstructor;
@@ -360,11 +360,12 @@ public class AgentImpl implements Agent, AgentImplMBean {
                 }
             }
 
-            if (this.routerID == Long.MIN_VALUE) {
+            if (this.routerID == RouterImpl.UNKNOWN_ROUTER_ID) {
                 this.routerID = rrm.getRouterID();
             } else if (this.routerID != rrm.getRouterID()) {
-                throw new RouterHandshakeException("Invalid router response: previous router ID  was " + this.agentID +
-                                                   " but server now advertises " + rrm.getRouterID());
+                logger.warn("Router ID has changed, was previously " + this.routerID + " but is now " +
+                            rrm.getRouterID());
+                this.routerID = rrm.getRouterID();
             }
 
             int hb = rrm.getHeartbeatPeriod();

--- a/programming-extensions/programming-extension-pamr/src/main/java/org/objectweb/proactive/extensions/pamr/router/RouterImpl.java
+++ b/programming-extensions/programming-extension-pamr/src/main/java/org/objectweb/proactive/extensions/pamr/router/RouterImpl.java
@@ -93,7 +93,7 @@ public class RouterImpl extends RouterInternal implements Runnable {
     /** Read {@link ByteBuffer} size. */
     private final static int READ_BUFFER_SIZE = 4096;
 
-    public final static long DEFAULT_ROUTER_ID = Long.MIN_VALUE;
+    public final static long UNKNOWN_ROUTER_ID = Long.MIN_VALUE;
 
     /** True is the router must stop or is stopped*/
     private final AtomicBoolean stopped = new AtomicBoolean(false);

--- a/programming-test/src/test/java/functionalTests/pamr/BlackBoxRegistered.java
+++ b/programming-test/src/test/java/functionalTests/pamr/BlackBoxRegistered.java
@@ -50,7 +50,7 @@ public class BlackBoxRegistered extends BlackBox {
         // Connect
         Message message = new RegistrationRequestMessage(null,
                                                          ProActiveRandom.nextPosLong(),
-                                                         RouterImpl.DEFAULT_ROUTER_ID,
+                                                         RouterImpl.UNKNOWN_ROUTER_ID,
                                                          new MagicCookie());
         tunnel.write(message.toByteArray());
 

--- a/programming-test/src/test/java/functionalTests/pamr/router/blackbox/TestClientEviction.java
+++ b/programming-test/src/test/java/functionalTests/pamr/router/blackbox/TestClientEviction.java
@@ -93,7 +93,7 @@ public class TestClientEviction extends FunctionalTest {
         MagicCookie magicCookie = new MagicCookie();
         Message message = new RegistrationRequestMessage(null,
                                                          ProActiveRandom.nextLong(),
-                                                         RouterImpl.DEFAULT_ROUTER_ID,
+                                                         RouterImpl.UNKNOWN_ROUTER_ID,
                                                          magicCookie);
         tunnel.write(message.toByteArray());
 

--- a/programming-test/src/test/java/functionalTests/pamr/router/blackbox/TestConnection.java
+++ b/programming-test/src/test/java/functionalTests/pamr/router/blackbox/TestConnection.java
@@ -53,7 +53,7 @@ public class TestConnection extends BlackBox {
         MagicCookie magicCookie = new MagicCookie();
         Message message = new RegistrationRequestMessage(null,
                                                          ProActiveRandom.nextPosLong(),
-                                                         RouterImpl.DEFAULT_ROUTER_ID,
+                                                         RouterImpl.UNKNOWN_ROUTER_ID,
                                                          magicCookie);
         tunnel.write(message.toByteArray());
 

--- a/programming-test/src/test/java/functionalTests/pamr/router/blackbox/TestRegistrationCorruption.java
+++ b/programming-test/src/test/java/functionalTests/pamr/router/blackbox/TestRegistrationCorruption.java
@@ -64,7 +64,7 @@ public class TestRegistrationCorruption extends BlackBox {
         MagicCookie magicCookie = new MagicCookie();
         Message message = new RegistrationRequestMessage(new AgentID(invalidAgentID),
                                                          msgId,
-                                                         RouterImpl.DEFAULT_ROUTER_ID,
+                                                         RouterImpl.UNKNOWN_ROUTER_ID,
                                                          magicCookie);
         tunnel.write(message.toByteArray());
 
@@ -78,7 +78,7 @@ public class TestRegistrationCorruption extends BlackBox {
         Assert.assertEquals(unknown, err.getFaulty());
 
         // Connect
-        message = new RegistrationRequestMessage(null, msgId, RouterImpl.DEFAULT_ROUTER_ID, magicCookie);
+        message = new RegistrationRequestMessage(null, msgId, RouterImpl.UNKNOWN_ROUTER_ID, magicCookie);
         tunnel.write(message.toByteArray());
 
         resp = tunnel.readMessage();

--- a/programming-test/src/test/java/functionalTests/pamr/router/blackbox/TestUnknownSender.java
+++ b/programming-test/src/test/java/functionalTests/pamr/router/blackbox/TestUnknownSender.java
@@ -81,7 +81,7 @@ public class TestUnknownSender extends BlackBox {
         // Connect
         Message message = new RegistrationRequestMessage(null,
                                                          ProActiveRandom.nextPosLong(),
-                                                         RouterImpl.DEFAULT_ROUTER_ID,
+                                                         RouterImpl.UNKNOWN_ROUTER_ID,
                                                          new MagicCookie());
         tunnel.write(message.toByteArray());
 


### PR DESCRIPTION
Currently, a pamr router restart freezes all pamr agents trying to reconnect but never managing to.
This change allows a reconnection from an agent to a restarted router, and works in best-effort mode:
  - It is not possible to guarantee that undelivered messages will be delivered after a restart.
  - It is also not possible to guarantee that an existing agent ID will not be stolen by a new agent after reconnection. But in scenarios where all agents try to reconnect, no ID theft should occur.

 Added new blackbox tests (and update existing ones) to verify the behavior.