### PR TITLE
Add credentials support to Data spaces

### DIFF
--- a/programming-extensions/programming-extension-dataspaces-common/src/main/java/org/objectweb/proactive/extensions/dataspaces/api/UserCredentials.java
+++ b/programming-extensions/programming-extension-dataspaces-common/src/main/java/org/objectweb/proactive/extensions/dataspaces/api/UserCredentials.java
@@ -1,0 +1,124 @@
+/*
+ * ProActive Parallel Suite(TM):
+ * The Open Source library for parallel and distributed
+ * Workflows & Scheduling, Orchestration, Cloud Automation
+ * and Big Data Analysis on Enterprise Grids & Clouds.
+ *
+ * Copyright (c) 2007 - 2017 ActiveEon
+ * Contact: contact@activeeon.com
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation: version 3 of
+ * the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ */
+package org.objectweb.proactive.extensions.dataspaces.api;
+
+import java.util.Arrays;
+
+
+/**
+ * @author ActiveEon Team
+ * @since 04/07/2020
+ */
+public class UserCredentials {
+
+    private String login;
+
+    private String password;
+
+    private String domain;
+
+    private byte[] privateKey;
+
+    public UserCredentials() {
+
+    }
+
+    public UserCredentials(String login, String password, String domain, byte[] privateKey) {
+        this.login = login;
+        this.password = password;
+        this.domain = domain;
+        this.privateKey = privateKey;
+    }
+
+    public String getLogin() {
+        return login;
+    }
+
+    public void setLogin(String login) {
+        this.login = login;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    public String getDomain() {
+        return domain;
+    }
+
+    public void setDomain(String domain) {
+        this.domain = domain;
+    }
+
+    public byte[] getPrivateKey() {
+        return privateKey;
+    }
+
+    public void setPrivateKey(byte[] privateKey) {
+        this.privateKey = privateKey;
+    }
+
+    public boolean isEmpty() {
+        return login == null;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+
+        UserCredentials that = (UserCredentials) o;
+
+        if (getLogin() != null ? !getLogin().equals(that.getLogin()) : that.getLogin() != null)
+            return false;
+        if (getPassword() != null ? !getPassword().equals(that.getPassword()) : that.getPassword() != null)
+            return false;
+        if (getDomain() != null ? !getDomain().equals(that.getDomain()) : that.getDomain() != null)
+            return false;
+        return Arrays.equals(getPrivateKey(), that.getPrivateKey());
+    }
+
+    @Override
+    public int hashCode() {
+        int result = getLogin() != null ? getLogin().hashCode() : 0;
+        result = 31 * result + (getPassword() != null ? getPassword().hashCode() : 0);
+        result = 31 * result + (getDomain() != null ? getDomain().hashCode() : 0);
+        result = 31 * result + Arrays.hashCode(getPrivateKey());
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "UserCredentials{" + "login='" + login + '\'' + ", password='" + password + '\'' + ", domain='" +
+               domain + '\'' + '}';
+    }
+}

--- a/programming-extensions/programming-extension-dataspaces/src/main/java/org/objectweb/proactive/extensions/dataspaces/api/PADataSpaces.java
+++ b/programming-extensions/programming-extension-dataspaces/src/main/java/org/objectweb/proactive/extensions/dataspaces/api/PADataSpaces.java
@@ -64,7 +64,7 @@ import org.objectweb.proactive.extensions.dataspaces.exceptions.SpaceNotFoundExc
  * {@link #getAllKnownInputNames()} and {@link #getAllKnownOutputNames()}</li>
  * <li>Methods for resolving {@link DataSpacesFileObject} instances from data spaces, all
  * <code>resolve*</code> methods. Those instances <b>must not</b> be shared between two different
- * ActiveObjects. Instead use {@link DataSpacesFileObject#getURI()} method for obtaining particular
+ * ActiveObjects. Instead use {@link DataSpacesFileObject#getRealURI()} ()} method for obtaining particular
  * file's URI, that is <b>allowed</b> to pass between two different ActiveObjects.</li>
  * </ol>
  * <p>
@@ -167,7 +167,31 @@ public class PADataSpaces {
      */
     public static DataSpacesFileObject resolveDefaultInput()
             throws SpaceNotFoundException, FileSystemException, NotConfiguredException, ConfigurationException {
-        return getMyDataSpacesImpl().resolveDefaultInputOutput(SpaceType.INPUT, null);
+        return getMyDataSpacesImpl().resolveDefaultInputOutput(SpaceType.INPUT, null, null);
+    }
+
+    /**
+     * Returns file handle to the <i>default input data space</i>. This method call is equal to
+     * {@link #resolveDefaultInput(String)} with null path argument.
+     *
+     * @param credentials
+     *             credentials used to access the file (for implementations which support it)
+     * @return file handle to the default input data space of caller's application
+     * @throws SpaceNotFoundException
+     *             when there is no default input data space defined
+     * @throws FileSystemException
+     *             indicates VFS related exception
+     * @throws NotConfiguredException
+     *             when caller's node is not configured for Data Spaces application
+     * @throws ConfigurationException
+     *             when resolved space's file system has not enough capabilities (because of wrong
+     *             configuration)
+     * @see #resolveDefaultInputBlocking(long)
+     * @see #resolveDefaultInput(String)
+     */
+    public static DataSpacesFileObject resolveDefaultInput(UserCredentials credentials)
+            throws SpaceNotFoundException, FileSystemException, NotConfiguredException, ConfigurationException {
+        return getMyDataSpacesImpl().resolveDefaultInputOutput(SpaceType.INPUT, null, credentials);
     }
 
     /**
@@ -201,7 +225,43 @@ public class PADataSpaces {
      */
     public static DataSpacesFileObject resolveDefaultInput(String path)
             throws SpaceNotFoundException, FileSystemException, NotConfiguredException, ConfigurationException {
-        return getMyDataSpacesImpl().resolveDefaultInputOutput(SpaceType.INPUT, path);
+        return getMyDataSpacesImpl().resolveDefaultInputOutput(SpaceType.INPUT, path, null);
+    }
+
+    /**
+     * Returns file handle to file specified by path in the <i>default input data space</i>, as
+     * defined in application descriptor or dynamically set through API during application
+     * execution.
+     * <p>
+     * Returned file handle can be directly used to perform operations on the file/directory,
+     * regardless of the underlying protocol. Closing returned DataSpacesFileObject is a caller's
+     * responsibility.
+     * <p>
+     * As input data space minimal capabilities are checked locally, its content is expected to be
+     * readable from any node of this application if it was defined correctly. It is intended to
+     * provide any form of input to the application.
+     *
+     * @param path
+     *            path of a file in the default input data space; <code>null</code> denotes request
+     *            for data space root
+     * @param credentials
+     *            credentials used to mount the file system
+     * @return file handle to file specified by path in the default input data space of caller's
+     *         application
+     * @throws SpaceNotFoundException
+     *             when there is no default input data space defined
+     * @throws FileSystemException
+     *             indicates VFS related exception
+     * @throws NotConfiguredException
+     *             when caller's node is not configured for Data Spaces application
+     * @throws ConfigurationException
+     *             when resolved space's file system has not enough capabilities (because of wrong
+     *             configuration)
+     * @see #resolveDefaultInputBlocking(String, long)
+     */
+    public static DataSpacesFileObject resolveDefaultInput(String path, UserCredentials credentials)
+            throws SpaceNotFoundException, FileSystemException, NotConfiguredException, ConfigurationException {
+        return getMyDataSpacesImpl().resolveDefaultInputOutput(SpaceType.INPUT, path, credentials);
     }
 
     /**
@@ -223,7 +283,31 @@ public class PADataSpaces {
      */
     public static DataSpacesFileObject resolveDefaultOutput()
             throws SpaceNotFoundException, FileSystemException, NotConfiguredException, ConfigurationException {
-        return getMyDataSpacesImpl().resolveDefaultInputOutput(SpaceType.OUTPUT, null);
+        return getMyDataSpacesImpl().resolveDefaultInputOutput(SpaceType.OUTPUT, null, null);
+    }
+
+    /**
+     * Returns file handle to the <i>default output data space</i>. This method call is equal to
+     * {@link #resolveDefaultOutput(String)} with null path argument.
+     *
+     * @param credentials
+     *             credentials used to access the file (for implementations which support it)
+     * @return file handle to the default output data space of caller's application
+     * @throws SpaceNotFoundException
+     *             when there is no default output data space defined
+     * @throws FileSystemException
+     *             indicates VFS related exception
+     * @throws NotConfiguredException
+     *             when caller's node is not configured for Data Spaces application
+     * @throws ConfigurationException
+     *             when resolved space's file system has not enough capabilities (because of wrong
+     *             configuration)
+     * @see #resolveDefaultOutputBlocking(long)
+     * @see #resolveDefaultOutput(String)
+     */
+    public static DataSpacesFileObject resolveDefaultOutput(UserCredentials credentials)
+            throws SpaceNotFoundException, FileSystemException, NotConfiguredException, ConfigurationException {
+        return getMyDataSpacesImpl().resolveDefaultInputOutput(SpaceType.OUTPUT, null, credentials);
     }
 
     /**
@@ -259,7 +343,45 @@ public class PADataSpaces {
      */
     public static DataSpacesFileObject resolveDefaultOutput(String path)
             throws SpaceNotFoundException, FileSystemException, NotConfiguredException, ConfigurationException {
-        return getMyDataSpacesImpl().resolveDefaultInputOutput(SpaceType.OUTPUT, path);
+        return getMyDataSpacesImpl().resolveDefaultInputOutput(SpaceType.OUTPUT, path, null);
+    }
+
+    /**
+     * Returns file handle to file specified by path in the <i>default output data space</i>, as
+     * defined in application descriptor or dynamically set through API during application
+     * execution.
+     * <p>
+     * Returned file handle can be directly used to perform operations on the file/directory,
+     * regardless of the underlying protocol. If specified file does not exist, one should call
+     * {@link DataSpacesFileObject#createFile()} or {@link DataSpacesFileObject#createFolder()}
+     * method. Closing returned DataSpacesFileObject is a caller's responsibility.
+     * <p>
+     * As output data space minimal capabilities are checked locally, its content is expected to be
+     * writable from any node of this application if it was defined correctly. It is intended to
+     * store globally any computation results. Writes synchronization is a developer’s
+     * responsibility.
+     *
+     * @param path
+     *            path of a file in the default output data space; <code>null</code> denotes request
+     *            for data space root
+     * @param credentials
+     *             credentials used to access the file (for implementations which support it)
+     * @return file handle to file specified by path in the default output data space of caller's
+     *         application
+     * @throws SpaceNotFoundException
+     *             when there is no default output data space defined
+     * @throws FileSystemException
+     *             indicates VFS related exception
+     * @throws NotConfiguredException
+     *             when caller's node is not configured for Data Spaces application
+     * @throws ConfigurationException
+     *             when resolved space's file system has not enough capabilities (because of wrong
+     *             configuration)
+     * @see #resolveDefaultOutputBlocking(String, long)
+     */
+    public static DataSpacesFileObject resolveDefaultOutput(String path, UserCredentials credentials)
+            throws SpaceNotFoundException, FileSystemException, NotConfiguredException, ConfigurationException {
+        return getMyDataSpacesImpl().resolveDefaultInputOutput(SpaceType.OUTPUT, path, credentials);
     }
 
     /**
@@ -288,7 +410,7 @@ public class PADataSpaces {
      */
     public static DataSpacesFileObject resolveDefaultInputBlocking(long timeoutMillis)
             throws ProActiveTimeoutException, FileSystemException, NotConfiguredException, ConfigurationException {
-        return getMyDataSpacesImpl().resolveDefaultInputOutputBlocking(timeoutMillis, SpaceType.INPUT, null);
+        return getMyDataSpacesImpl().resolveDefaultInputOutputBlocking(timeoutMillis, SpaceType.INPUT, null, null);
     }
 
     /**
@@ -322,7 +444,7 @@ public class PADataSpaces {
     public static DataSpacesFileObject resolveDefaultInputBlocking(String path, long timeoutMillis)
             throws IllegalArgumentException, ProActiveTimeoutException, FileSystemException, NotConfiguredException,
             ConfigurationException {
-        return getMyDataSpacesImpl().resolveDefaultInputOutputBlocking(timeoutMillis, SpaceType.INPUT, path);
+        return getMyDataSpacesImpl().resolveDefaultInputOutputBlocking(timeoutMillis, SpaceType.INPUT, path, null);
     }
 
     /**
@@ -351,7 +473,7 @@ public class PADataSpaces {
      */
     public static DataSpacesFileObject resolveDefaultOutputBlocking(long timeoutMillis) throws IllegalArgumentException,
             ProActiveTimeoutException, FileSystemException, NotConfiguredException, ConfigurationException {
-        return getMyDataSpacesImpl().resolveDefaultInputOutputBlocking(timeoutMillis, SpaceType.OUTPUT, null);
+        return getMyDataSpacesImpl().resolveDefaultInputOutputBlocking(timeoutMillis, SpaceType.OUTPUT, null, null);
     }
 
     /**
@@ -385,7 +507,7 @@ public class PADataSpaces {
     public static DataSpacesFileObject resolveDefaultOutputBlocking(String path, long timeoutMillis)
             throws IllegalArgumentException, ProActiveTimeoutException, FileSystemException, NotConfiguredException,
             ConfigurationException {
-        return getMyDataSpacesImpl().resolveDefaultInputOutputBlocking(timeoutMillis, SpaceType.OUTPUT, path);
+        return getMyDataSpacesImpl().resolveDefaultInputOutputBlocking(timeoutMillis, SpaceType.OUTPUT, path, null);
     }
 
     /**
@@ -409,7 +531,33 @@ public class PADataSpaces {
      */
     public static DataSpacesFileObject resolveInput(String name)
             throws SpaceNotFoundException, FileSystemException, NotConfiguredException, ConfigurationException {
-        return getMyDataSpacesImpl().resolveInputOutput(name, SpaceType.INPUT, null);
+        return getMyDataSpacesImpl().resolveInputOutput(name, SpaceType.INPUT, null, null);
+    }
+
+    /**
+     * Returns file handle to the <i>input data space</i> with specific name. This method call is
+     * equal to {@link #resolveInput(String, String)} with null path argument.
+     *
+     * @param name
+     *            name of an input data space to resolve
+     * @param credentials
+     *             credentials used to access the file (for implementations which support it)
+     * @return file handle to the input data space with provided name, for caller's application
+     * @throws SpaceNotFoundException
+     *             when there is no input data space defined with specified name
+     * @throws FileSystemException
+     *             indicates VFS related exception
+     * @throws NotConfiguredException
+     *             when caller's node is not configured for Data Spaces application
+     * @throws ConfigurationException
+     *             when resolved space's file system has not enough capabilities (because of wrong
+     *             configuration)
+     * @see #resolveInputBlocking(String, long)
+     * @see #resolveInput(String, String)
+     */
+    public static DataSpacesFileObject resolveInput(String name, UserCredentials credentials)
+            throws SpaceNotFoundException, FileSystemException, NotConfiguredException, ConfigurationException {
+        return getMyDataSpacesImpl().resolveInputOutput(name, SpaceType.INPUT, null, credentials);
     }
 
     /**
@@ -445,7 +593,45 @@ public class PADataSpaces {
      */
     public static DataSpacesFileObject resolveInput(String name, String path)
             throws SpaceNotFoundException, FileSystemException, NotConfiguredException, ConfigurationException {
-        return getMyDataSpacesImpl().resolveInputOutput(name, SpaceType.INPUT, path);
+        return getMyDataSpacesImpl().resolveInputOutput(name, SpaceType.INPUT, path, null);
+    }
+
+    /**
+     * Returns file handle to file specified by path in the <i>input data space</i> with specific
+     * name, as defined in application descriptor or dynamically set through API during application
+     * execution.
+     * <p>
+     * Returned file handle can be directly used to perform operations on the file/directory,
+     * regardless of the underlying protocol. Closing returned DataSpacesFileObject is a caller's
+     * responsibility.
+     * <p>
+     * As input data space capabilities are checked locally, its content is expected to be readable
+     * from any node of this application if it was defined correctly. It is intended to provide any
+     * form of input to the application.
+     *
+     * @param name
+     *            name of an input data space to resolve
+     * @param path
+     *            path of a file in the named input data space; <code>null</code> denotes request
+     *            for data space root
+     * @param credentials
+     *             credentials used to access the file (for implementations which support it)
+     * @return file handle to file specified by path in the input data space with provided name, for
+     *         caller's application
+     * @throws SpaceNotFoundException
+     *             when there is no input data space defined with specified name
+     * @throws FileSystemException
+     *             indicates VFS related exception
+     * @throws NotConfiguredException
+     *             when caller's node is not configured for Data Spaces application
+     * @throws ConfigurationException
+     *             when resolved space's file system has not enough capabilities (because of wrong
+     *             configuration)
+     * @see #resolveInputBlocking(String, String, long)
+     */
+    public static DataSpacesFileObject resolveInput(String name, UserCredentials credentials, String path)
+            throws SpaceNotFoundException, FileSystemException, NotConfiguredException, ConfigurationException {
+        return getMyDataSpacesImpl().resolveInputOutput(name, SpaceType.INPUT, path, credentials);
     }
 
     /**
@@ -469,7 +655,33 @@ public class PADataSpaces {
      */
     public static DataSpacesFileObject resolveOutput(String name)
             throws SpaceNotFoundException, FileSystemException, NotConfiguredException, ConfigurationException {
-        return getMyDataSpacesImpl().resolveInputOutput(name, SpaceType.OUTPUT, null);
+        return getMyDataSpacesImpl().resolveInputOutput(name, SpaceType.OUTPUT, null, null);
+    }
+
+    /**
+     * Returns file handle to the <i>output data space</i> with specific name. This method call is
+     * equal to {@link #resolveOutput(String, String)} with null path argument.
+     *
+     * @param name
+     *            name of an output data space to resolve
+     * @param credentials
+     *             credentials used to access the file (for implementations which support it)
+     * @return file handle to the output data space with provided name, for caller's application
+     * @throws SpaceNotFoundException
+     *             when there is no output data space defined with specified name
+     * @throws FileSystemException
+     *             indicates VFS related exception
+     * @throws NotConfiguredException
+     *             when caller's node is not configured for Data Spaces application
+     * @throws ConfigurationException
+     *             when resolved space's file system has not enough capabilities (because of wrong
+     *             configuration)
+     * @see #resolveOutputBlocking(String, long)
+     * @see #resolveOutput(String, String)
+     */
+    public static DataSpacesFileObject resolveOutput(String name, UserCredentials credentials)
+            throws SpaceNotFoundException, FileSystemException, NotConfiguredException, ConfigurationException {
+        return getMyDataSpacesImpl().resolveInputOutput(name, SpaceType.OUTPUT, null, credentials);
     }
 
     /**
@@ -506,7 +718,46 @@ public class PADataSpaces {
      */
     public static DataSpacesFileObject resolveOutput(String name, String path)
             throws SpaceNotFoundException, FileSystemException, NotConfiguredException, ConfigurationException {
-        return getMyDataSpacesImpl().resolveInputOutput(name, SpaceType.OUTPUT, path);
+        return getMyDataSpacesImpl().resolveInputOutput(name, SpaceType.OUTPUT, path, null);
+    }
+
+    /**
+     * Returns file handle to file specified by path in the <i>output data space</i> with specific
+     * name, as defined in application descriptor or dynamically set through API during application
+     * execution.
+     * <p>
+     * Returned file handle can be directly used to perform operations on the file/directory,
+     * regardless of the underlying protocol. If specified file does not exist, one should call
+     * {@link DataSpacesFileObject#createFile()} or {@link DataSpacesFileObject#createFolder()}
+     * method. Closing returned DataSpacesFileObject is a caller's responsibility.
+     * <p>
+     * Output data space content is expected to be writable from any node of this application if it
+     * was defined correctly. It is intended to store globally any computation results. Writes
+     * synchronization is a developer’s responsibility.
+     *
+     * @param name
+     *            name of an output data space to resolve
+     * @param path
+     *            path of a file in the named output data space; <code>null</code> denotes request
+     *            for data space root
+     * @param credentials
+     *             credentials used to access the file (for implementations which support it)
+     * @return file handle to file specified by path in the output data space with provided name,
+     *         for caller's application
+     * @throws SpaceNotFoundException
+     *             when there is no output data space defined with specified name
+     * @throws FileSystemException
+     *             indicates VFS related exception
+     * @throws NotConfiguredException
+     *             when caller's node is not configured for Data Spaces application
+     * @throws ConfigurationException
+     *             when resolved space's file system has not enough capabilities (because of wrong
+     *             configuration)
+     * @see #resolveOutputBlocking(String, String, long)
+     */
+    public static DataSpacesFileObject resolveOutput(String name, UserCredentials credentials, String path)
+            throws SpaceNotFoundException, FileSystemException, NotConfiguredException, ConfigurationException {
+        return getMyDataSpacesImpl().resolveInputOutput(name, SpaceType.OUTPUT, path, credentials);
     }
 
     /**
@@ -539,7 +790,7 @@ public class PADataSpaces {
     public static DataSpacesFileObject resolveInputBlocking(String name, long timeoutMillis)
             throws IllegalArgumentException, ProActiveTimeoutException, FileSystemException, NotConfiguredException,
             ConfigurationException {
-        return getMyDataSpacesImpl().resolveInputOutputBlocking(name, timeoutMillis, SpaceType.INPUT, null);
+        return getMyDataSpacesImpl().resolveInputOutputBlocking(name, timeoutMillis, SpaceType.INPUT, null, null);
     }
 
     /**
@@ -576,7 +827,7 @@ public class PADataSpaces {
     public static DataSpacesFileObject resolveInputBlocking(String name, String path, long timeoutMillis)
             throws IllegalArgumentException, ProActiveTimeoutException, FileSystemException, NotConfiguredException,
             ConfigurationException {
-        return getMyDataSpacesImpl().resolveInputOutputBlocking(name, timeoutMillis, SpaceType.INPUT, path);
+        return getMyDataSpacesImpl().resolveInputOutputBlocking(name, timeoutMillis, SpaceType.INPUT, path, null);
     }
 
     /**
@@ -609,7 +860,7 @@ public class PADataSpaces {
     public static DataSpacesFileObject resolveOutputBlocking(String name, long timeoutMillis)
             throws IllegalArgumentException, ProActiveTimeoutException, FileSystemException, NotConfiguredException,
             ConfigurationException {
-        return getMyDataSpacesImpl().resolveInputOutputBlocking(name, timeoutMillis, SpaceType.OUTPUT, null);
+        return getMyDataSpacesImpl().resolveInputOutputBlocking(name, timeoutMillis, SpaceType.OUTPUT, null, null);
     }
 
     /**
@@ -646,7 +897,7 @@ public class PADataSpaces {
     public static DataSpacesFileObject resolveOutputBlocking(String name, String path, long timeoutMillis)
             throws IllegalArgumentException, ProActiveTimeoutException, FileSystemException, NotConfiguredException,
             ConfigurationException {
-        return getMyDataSpacesImpl().resolveInputOutputBlocking(name, timeoutMillis, SpaceType.OUTPUT, path);
+        return getMyDataSpacesImpl().resolveInputOutputBlocking(name, timeoutMillis, SpaceType.OUTPUT, path, null);
     }
 
     /**
@@ -669,7 +920,7 @@ public class PADataSpaces {
      */
     public static DataSpacesFileObject resolveScratchForAO()
             throws FileSystemException, NotConfiguredException, ConfigurationException {
-        return getMyDataSpacesImpl().resolveScratchForAO(null);
+        return getMyDataSpacesImpl().resolveScratchForAO(null, null);
     }
 
     /**
@@ -705,7 +956,7 @@ public class PADataSpaces {
      */
     public static DataSpacesFileObject resolveScratchForAO(String path)
             throws FileSystemException, NotConfiguredException, ConfigurationException {
-        return getMyDataSpacesImpl().resolveScratchForAO(path);
+        return getMyDataSpacesImpl().resolveScratchForAO(path, null);
     }
 
     /**
@@ -785,7 +1036,7 @@ public class PADataSpaces {
      */
     public static Map<String, DataSpacesFileObject> resolveAllKnownInputs()
             throws FileSystemException, NotConfiguredException, ConfigurationException {
-        return getMyDataSpacesImpl().resolveAllKnownInputsOutputs(SpaceType.INPUT);
+        return getMyDataSpacesImpl().resolveAllKnownInputsOutputs(SpaceType.INPUT, null);
     }
 
     /**
@@ -823,7 +1074,7 @@ public class PADataSpaces {
      */
     public static Map<String, DataSpacesFileObject> resolveAllKnownOutputs()
             throws FileSystemException, NotConfiguredException, ConfigurationException {
-        return getMyDataSpacesImpl().resolveAllKnownInputsOutputs(SpaceType.OUTPUT);
+        return getMyDataSpacesImpl().resolveAllKnownInputsOutputs(SpaceType.OUTPUT, null);
     }
 
     /**
@@ -848,7 +1099,7 @@ public class PADataSpaces {
      *
      * @param uri
      *            valid URI within an existing data space, returned by
-     *            {@link DataSpacesFileObject#getURI()}
+     *            {@link DataSpacesFileObject#getRealURI()}
      * @return handle for specified file
      * @throws MalformedURIException
      *             passed URI is invalid or not suitable for use by user (accessing internal
@@ -862,11 +1113,11 @@ public class PADataSpaces {
      * @throws ConfigurationException
      *             when resolved space's file system has not enough capabilities (because of wrong
      *             configuration)
-     * @see DataSpacesFileObject#getURI()
+     * @see DataSpacesFileObject#getRealURI()
      */
     public static DataSpacesFileObject resolveFile(String uri) throws MalformedURIException, SpaceNotFoundException,
             FileSystemException, NotConfiguredException, ConfigurationException {
-        return getMyDataSpacesImpl().resolveFile(uri);
+        return getMyDataSpacesImpl().resolveFile(uri, null);
     }
 
     /**

--- a/programming-extensions/programming-extension-dataspaces/src/main/java/org/objectweb/proactive/extensions/dataspaces/console/NamingServiceListing.java
+++ b/programming-extensions/programming-extension-dataspaces/src/main/java/org/objectweb/proactive/extensions/dataspaces/console/NamingServiceListing.java
@@ -110,7 +110,7 @@ public class NamingServiceListing {
         mountManager = new VFSSpacesMountManagerImpl(namingService);
 
         // get FileObject for each space
-        final Map<DataSpacesURI, DataSpacesFileObject> files = mountManager.resolveSpaces(query, null);
+        final Map<DataSpacesURI, DataSpacesFileObject> files = mountManager.resolveSpaces(query, null, null);
 
         for (Entry<DataSpacesURI, DataSpacesFileObject> space : files.entrySet()) {
             try {

--- a/programming-extensions/programming-extension-dataspaces/src/main/java/org/objectweb/proactive/extensions/dataspaces/core/DataSpacesImpl.java
+++ b/programming-extensions/programming-extension-dataspaces/src/main/java/org/objectweb/proactive/extensions/dataspaces/core/DataSpacesImpl.java
@@ -42,6 +42,7 @@ import org.objectweb.proactive.extensions.dataspaces.Utils;
 import org.objectweb.proactive.extensions.dataspaces.api.Capability;
 import org.objectweb.proactive.extensions.dataspaces.api.DataSpacesFileObject;
 import org.objectweb.proactive.extensions.dataspaces.api.PADataSpaces;
+import org.objectweb.proactive.extensions.dataspaces.api.UserCredentials;
 import org.objectweb.proactive.extensions.dataspaces.core.naming.SpacesDirectory;
 import org.objectweb.proactive.extensions.dataspaces.exceptions.ConfigurationException;
 import org.objectweb.proactive.extensions.dataspaces.exceptions.FileSystemException;
@@ -158,9 +159,9 @@ public class DataSpacesImpl {
      * @see PADataSpaces#resolveDefaultInput()
      * @see PADataSpaces#resolveDefaultOutput()
      */
-    public DataSpacesFileObject resolveDefaultInputOutput(SpaceType type, String path)
+    public DataSpacesFileObject resolveDefaultInputOutput(SpaceType type, String path, UserCredentials credentials)
             throws IllegalArgumentException, FileSystemException, SpaceNotFoundException, ConfigurationException {
-        return resolveInputOutput(PADataSpaces.DEFAULT_IN_OUT_NAME, type, path);
+        return resolveInputOutput(PADataSpaces.DEFAULT_IN_OUT_NAME, type, path, credentials);
     }
 
     /**
@@ -170,9 +171,10 @@ public class DataSpacesImpl {
      * @see PADataSpaces#resolveDefaultInputBlocking(long)
      * @see PADataSpaces#resolveDefaultOutputBlocking(long)
      */
-    public DataSpacesFileObject resolveDefaultInputOutputBlocking(long timeoutMillis, SpaceType type, String path)
+    public DataSpacesFileObject resolveDefaultInputOutputBlocking(long timeoutMillis, SpaceType type, String path,
+            UserCredentials credentials)
             throws IllegalArgumentException, FileSystemException, ProActiveTimeoutException, ConfigurationException {
-        return resolveInputOutputBlocking(PADataSpaces.DEFAULT_IN_OUT_NAME, timeoutMillis, type, path);
+        return resolveInputOutputBlocking(PADataSpaces.DEFAULT_IN_OUT_NAME, timeoutMillis, type, path, credentials);
     }
 
     /**
@@ -181,7 +183,8 @@ public class DataSpacesImpl {
      * @see PADataSpaces#resolveInput(String)
      * @see PADataSpaces#resolveOutput(String)
      */
-    public DataSpacesFileObject resolveInputOutput(String name, SpaceType type, String path)
+    public DataSpacesFileObject resolveInputOutput(String name, SpaceType type, String path,
+            UserCredentials credentials)
             throws FileSystemException, IllegalArgumentException, SpaceNotFoundException, ConfigurationException {
         if (logger.isTraceEnabled())
             logger.trace(String.format("Resolving request for %s with name %s", type, name));
@@ -198,7 +201,7 @@ public class DataSpacesImpl {
 
         try {
             final String aoId = Utils.getActiveObjectId(Utils.getCurrentActiveObjectBody());
-            final DataSpacesFileObject fo = spacesMountManager.resolveFile(uri, aoId);
+            final DataSpacesFileObject fo = spacesMountManager.resolveFile(uri, aoId, credentials);
             if (logger.isTraceEnabled())
                 logger.trace(String.format("Resolved request for %s with name %s (%s)", type, name, uri));
 
@@ -219,7 +222,8 @@ public class DataSpacesImpl {
      * @see PADataSpaces#resolveInputBlocking(String, long)
      * @see PADataSpaces#resolveOutputBlocking(String, long)
      */
-    public DataSpacesFileObject resolveInputOutputBlocking(String name, long timeoutMillis, SpaceType type, String path)
+    public DataSpacesFileObject resolveInputOutputBlocking(String name, long timeoutMillis, SpaceType type, String path,
+            UserCredentials credentials)
             throws FileSystemException, IllegalArgumentException, ProActiveTimeoutException, ConfigurationException {
         if (logger.isTraceEnabled())
             logger.trace(String.format("Resolving blocking request for %s with name %s", type, name));
@@ -243,7 +247,7 @@ public class DataSpacesImpl {
         while (currTime < startTime + timeoutMillis) {
             try {
                 final String aoId = Utils.getActiveObjectId(Utils.getCurrentActiveObjectBody());
-                final DataSpacesFileObject fo = spacesMountManager.resolveFile(uri, aoId);
+                final DataSpacesFileObject fo = spacesMountManager.resolveFile(uri, aoId, credentials);
                 if (logger.isTraceEnabled()) {
                     final String message = String.format("Resolved blocking request for %s with name %s (%s)",
                                                          type,
@@ -286,7 +290,7 @@ public class DataSpacesImpl {
     /**
      * @see PADataSpaces#resolveScratchForAO()
      */
-    public DataSpacesFileObject resolveScratchForAO(String path)
+    public DataSpacesFileObject resolveScratchForAO(String path, UserCredentials credentials)
             throws FileSystemException, NotConfiguredException, ConfigurationException {
         logger.trace("Resolving scratch for an Active Object");
         if (appScratchSpace == null) {
@@ -299,7 +303,7 @@ public class DataSpacesImpl {
             final DataSpacesURI scratchURI = appScratchSpace.getScratchForAO(body);
             final DataSpacesURI queryURI = scratchURI.withUserPath(path);
             final String aoId = Utils.getActiveObjectId(Utils.getCurrentActiveObjectBody());
-            final DataSpacesFileObject fo = spacesMountManager.resolveFile(queryURI, aoId);
+            final DataSpacesFileObject fo = spacesMountManager.resolveFile(queryURI, aoId, credentials);
 
             if (logger.isTraceEnabled())
                 logger.trace("Resolved scratch for an Active Object: " + queryURI);
@@ -346,7 +350,7 @@ public class DataSpacesImpl {
      * @see PADataSpaces#resolveAllKnownInputs()
      * @see PADataSpaces#resolveAllKnownOutputs()
      */
-    public Map<String, DataSpacesFileObject> resolveAllKnownInputsOutputs(SpaceType type)
+    public Map<String, DataSpacesFileObject> resolveAllKnownInputsOutputs(SpaceType type, UserCredentials credentials)
             throws FileSystemException, IllegalArgumentException, ConfigurationException {
         if (logger.isTraceEnabled())
             logger.trace(String.format("Resolving known %s spaces: ", type));
@@ -356,7 +360,7 @@ public class DataSpacesImpl {
         final Map<DataSpacesURI, DataSpacesFileObject> spaces;
         try {
             final String aoId = Utils.getActiveObjectId(Utils.getCurrentActiveObjectBody());
-            spaces = spacesMountManager.resolveSpaces(uri, aoId);
+            spaces = spacesMountManager.resolveSpaces(uri, aoId, credentials);
         } catch (FileSystemException x) {
             logger.debug(String.format("VFS-level problem during resolving known %s spaces: ", type), x);
             throw x;
@@ -383,7 +387,7 @@ public class DataSpacesImpl {
     /**
      * @see PADataSpaces#resolveFile(String)
      */
-    public DataSpacesFileObject resolveFile(String uri)
+    public DataSpacesFileObject resolveFile(String uri, UserCredentials credentials)
             throws MalformedURIException, FileSystemException, SpaceNotFoundException, ConfigurationException {
         if (logger.isTraceEnabled())
             logger.trace("Resolving file: " + uri);
@@ -394,7 +398,7 @@ public class DataSpacesImpl {
                 throw new MalformedURIException("Specified URI represents internal high-level directories");
 
             final String aoId = Utils.getActiveObjectId(Utils.getCurrentActiveObjectBody());
-            final DataSpacesFileObject fo = spacesMountManager.resolveFile(dataSpacesURI, aoId);
+            final DataSpacesFileObject fo = spacesMountManager.resolveFile(dataSpacesURI, aoId, credentials);
             SpaceType type = dataSpacesURI.getSpaceType(); // as isComplete cannot be null
 
             if (logger.isTraceEnabled())

--- a/programming-extensions/programming-extension-dataspaces/src/main/java/org/objectweb/proactive/extensions/dataspaces/core/SpacesMountManager.java
+++ b/programming-extensions/programming-extension-dataspaces/src/main/java/org/objectweb/proactive/extensions/dataspaces/core/SpacesMountManager.java
@@ -28,6 +28,7 @@ package org.objectweb.proactive.extensions.dataspaces.core;
 import java.util.Map;
 
 import org.objectweb.proactive.extensions.dataspaces.api.DataSpacesFileObject;
+import org.objectweb.proactive.extensions.dataspaces.api.UserCredentials;
 import org.objectweb.proactive.extensions.dataspaces.core.naming.SpacesDirectory;
 import org.objectweb.proactive.extensions.dataspaces.exceptions.FileSystemException;
 import org.objectweb.proactive.extensions.dataspaces.exceptions.SpaceNotFoundException;
@@ -79,6 +80,8 @@ public interface SpacesMountManager {
      *            Id of active object requesting this file, that will become owner of returned
      *            {@link DataSpacesFileObject} instance. May be <code>null</code>, which corresponds
      *            to anonymous (unimportant) owner.
+     * @param credentials
+     *             credentials used to access the file (for implementations which support it)
      * @return {@link DataSpacesFileObject} instance that can be used to access this URI content;
      *         returned DataSpacesFileObject is not opened nor attached in any way; this
      *         DataSpacesFileObject instance will never be shared, i.e. individual instances are
@@ -92,8 +95,8 @@ public interface SpacesMountManager {
      *             when provided queryUri is not suitable for user path
      * @see DataSpacesURI#isSuitableForUserPath()
      */
-    public abstract DataSpacesFileObject resolveFile(final DataSpacesURI queryUri, final String ownerActiveObjectId)
-            throws FileSystemException, SpaceNotFoundException;
+    DataSpacesFileObject resolveFile(final DataSpacesURI queryUri, final String ownerActiveObjectId,
+            UserCredentials credentials) throws FileSystemException, SpaceNotFoundException;
 
     /**
      * Resolve query for URI without space part being fully defined, resulting in file-level access
@@ -118,6 +121,8 @@ public interface SpacesMountManager {
      *            Id of active object requesting this files, that will become owner of returned
      *            {@link DataSpacesFileObject} instances. May be <code>null</code>, which
      *            corresponds to anonymous (unimportant) owner.
+     * @param credentials
+     *             credentials used to access the file (for implementations which support it)
      * @return map of data spaces URIs suitable for user path that match the query, pointing to
      *         {@link DataSpacesFileObject} instances that can be used to access their content;
      *         returned DataSpacesFileObject are not opened nor attached in any way; these
@@ -132,8 +137,8 @@ public interface SpacesMountManager {
      * @see DataSpacesURI#isSpacePartFullyDefined()
      * @see DataSpacesURI#isSuitableForUserPath()
      */
-    public abstract Map<DataSpacesURI, DataSpacesFileObject> resolveSpaces(final DataSpacesURI queryUri,
-            final String ownerActiveObjectId) throws FileSystemException;
+    Map<DataSpacesURI, DataSpacesFileObject> resolveSpaces(final DataSpacesURI queryUri,
+            final String ownerActiveObjectId, UserCredentials credentials) throws FileSystemException;
 
     /**
      * Closes this manager instance, releasing any opened resources.
@@ -144,5 +149,5 @@ public interface SpacesMountManager {
      * <p>
      * Subsequent calls to these method may result in undefined behavior.
      */
-    public abstract void close();
+    void close();
 }

--- a/programming-extensions/programming-extension-dataspaces/src/main/java/org/objectweb/proactive/extensions/dataspaces/vfs/adapter/VFSFileObjectAdapter.java
+++ b/programming-extensions/programming-extension-dataspaces/src/main/java/org/objectweb/proactive/extensions/dataspaces/vfs/adapter/VFSFileObjectAdapter.java
@@ -48,6 +48,7 @@ import org.objectweb.proactive.extensions.dataspaces.api.DataSpacesFileObject;
 import org.objectweb.proactive.extensions.dataspaces.api.FileContent;
 import org.objectweb.proactive.extensions.dataspaces.api.FileSelector;
 import org.objectweb.proactive.extensions.dataspaces.api.FileType;
+import org.objectweb.proactive.extensions.dataspaces.api.UserCredentials;
 import org.objectweb.proactive.extensions.dataspaces.core.DataSpacesURI;
 import org.objectweb.proactive.extensions.dataspaces.exceptions.DataSpacesException;
 import org.objectweb.proactive.extensions.dataspaces.exceptions.FileSystemException;
@@ -94,15 +95,17 @@ public class VFSFileObjectAdapter implements DataSpacesFileObject {
 
     private final String ownerActiveObjectId;
 
+    private final UserCredentials credentials;
+
     public VFSFileObjectAdapter(FileObject adaptee, DataSpacesURI dataSpaceURI, FileName dataSpaceVFSFileName,
-            ArrayList<String> spaceRoots, String currentRoot) throws FileSystemException {
-        this(adaptee, dataSpaceURI, dataSpaceVFSFileName, spaceRoots, currentRoot, null, null);
+            ArrayList<String> spaceRoots, String currentRoot, UserCredentials credentials) throws FileSystemException {
+        this(adaptee, dataSpaceURI, dataSpaceVFSFileName, spaceRoots, currentRoot, null, null, credentials);
     }
 
     public VFSFileObjectAdapter(FileObject adaptee, DataSpacesURI dataSpaceURI, FileName dataSpaceVFSFileName,
-            ArrayList<String> spaceRoots, String currentRoot, VFSSpacesMountManagerImpl manager)
-            throws FileSystemException {
-        this(adaptee, dataSpaceURI, dataSpaceVFSFileName, spaceRoots, currentRoot, manager, null);
+            ArrayList<String> spaceRoots, String currentRoot, VFSSpacesMountManagerImpl manager,
+            UserCredentials credentials) throws FileSystemException {
+        this(adaptee, dataSpaceURI, dataSpaceVFSFileName, spaceRoots, currentRoot, manager, null, credentials);
     }
 
     /**
@@ -115,7 +118,7 @@ public class VFSFileObjectAdapter implements DataSpacesFileObject {
      */
     public VFSFileObjectAdapter(FileObject adaptee, DataSpacesURI dataSpaceURI, FileName dataSpaceVFSFileName,
             ArrayList<String> spaceRoots, String currentRoot, VFSSpacesMountManagerImpl manager,
-            String ownerActiveObjectId) throws FileSystemException {
+            String ownerActiveObjectId, UserCredentials credentials) throws FileSystemException {
         this.dataSpaceURI = dataSpaceURI;
         this.dataSpaceVFSFileName = dataSpaceVFSFileName;
         this.currentFileObject = adaptee;
@@ -123,6 +126,7 @@ public class VFSFileObjectAdapter implements DataSpacesFileObject {
         this.manager = manager;
         this.ownerActiveObjectId = ownerActiveObjectId;
         this.currentRootFOUri = currentRoot;
+        this.credentials = credentials;
         checkFileNamesConsistencyOrWound();
     }
 
@@ -134,7 +138,8 @@ public class VFSFileObjectAdapter implements DataSpacesFileObject {
              new ArrayList<String>(fileObjectAdapter.rootFOUriSet),
              fileObjectAdapter.currentRootFOUri,
              fileObjectAdapter.manager,
-             fileObjectAdapter.ownerActiveObjectId);
+             fileObjectAdapter.ownerActiveObjectId,
+             fileObjectAdapter.credentials);
     }
 
     public void close() throws FileSystemException {
@@ -666,7 +671,8 @@ public class VFSFileObjectAdapter implements DataSpacesFileObject {
         String relativePath = computeRelativePath();
         DataSpacesFileObject newDsfo = manager.resolveFile(dataSpaceURI.withRelativeToSpace(relativePath),
                                                            ownerActiveObjectId,
-                                                           spaceRootUri);
+                                                           spaceRootUri,
+                                                           credentials);
         logger.debug("switched to " + newDsfo.getRealURI());
         return newDsfo;
     }

--- a/programming-extensions/programming-extension-dataspaces/src/test/java/dataspaces/VFSFileObjectAdapterTest.java
+++ b/programming-extensions/programming-extension-dataspaces/src/test/java/dataspaces/VFSFileObjectAdapterTest.java
@@ -132,7 +132,7 @@ public class VFSFileObjectAdapterTest {
         rootUris.add(rootFileUri);
         rootUris.add(vfsServerUrl);
 
-        dsFileObject = new VFSFileObjectAdapter(adaptee, spaceURI, mountintPointFileName, rootUris, rootFileUri);
+        dsFileObject = new VFSFileObjectAdapter(adaptee, spaceURI, mountintPointFileName, rootUris, rootFileUri, null);
     }
 
     @After
@@ -156,7 +156,8 @@ public class VFSFileObjectAdapterTest {
                                                                  spaceURI,
                                                                  mountintPointFileName,
                                                                  rootUris,
-                                                                 rootFileUri);
+                                                                 rootFileUri,
+                                                                 null);
 
         assertEquals(spaceURI.toString(), fo.getVirtualURI());
     }
@@ -224,7 +225,8 @@ public class VFSFileObjectAdapterTest {
                                                                  spaceURI,
                                                                  mountintPointFileName,
                                                                  fos,
-                                                                 "file:///");
+                                                                 "file:///",
+                                                                 null);
         fo.getParent();
     }
 
@@ -238,7 +240,7 @@ public class VFSFileObjectAdapterTest {
         final FileName diffName;
         diffName = fileSystemManager.resolveFile(differentDirPath).getName();
 
-        new VFSFileObjectAdapter(adaptee, spaceURI, diffName, rootUris, rootUris.get(0));
+        new VFSFileObjectAdapter(adaptee, spaceURI, diffName, rootUris, rootUris.get(0), null);
     }
 
     private void assertIsSomeDir(DataSpacesFileObject parent) throws FileSystemException {

--- a/programming-extensions/programming-extension-dataspaces/src/test/java/dataspaces/VFSMountManagerHelperTerminateTest.java
+++ b/programming-extensions/programming-extension-dataspaces/src/test/java/dataspaces/VFSMountManagerHelperTerminateTest.java
@@ -39,6 +39,7 @@ import org.objectweb.proactive.core.ProActiveException;
 import org.objectweb.proactive.core.config.CentralPAPropertyRepository;
 import org.objectweb.proactive.core.util.log.Loggers;
 import org.objectweb.proactive.core.util.log.ProActiveLogger;
+import org.objectweb.proactive.extensions.dataspaces.api.UserCredentials;
 import org.objectweb.proactive.extensions.dataspaces.vfs.VFSMountManagerHelper;
 import org.objectweb.proactive.extensions.vfsprovider.FileSystemServerDeployer;
 
@@ -66,17 +67,17 @@ public class VFSMountManagerHelperTerminateTest {
 
         String[] validUrls = server.getVFSRootURLs();
         for (String validUrl : validUrls) {
-            FileObject mounted = VFSMountManagerHelper.mount(validUrl);
+            FileObject mounted = VFSMountManagerHelper.mount(new UserCredentials(), validUrl);
             Assert.assertTrue(mounted.exists());
         }
 
         VFSMountManagerHelper.terminate();
 
-        VFSMountManagerHelper.closeFileSystems(Arrays.asList(validUrls));
+        VFSMountManagerHelper.closeFileSystems(new UserCredentials(), Arrays.asList(validUrls));
 
         // Ensure that we can regenerate the mount helper
         for (String validUrl : validUrls) {
-            FileObject mounted = VFSMountManagerHelper.mount(validUrl);
+            FileObject mounted = VFSMountManagerHelper.mount(new UserCredentials(), validUrl);
             Assert.assertTrue(mounted.exists());
         }
 

--- a/programming-extensions/programming-extension-dataspaces/src/test/java/dataspaces/VFSMountManagerHelperTest.java
+++ b/programming-extensions/programming-extension-dataspaces/src/test/java/dataspaces/VFSMountManagerHelperTest.java
@@ -48,6 +48,7 @@ import org.objectweb.proactive.core.ProActiveException;
 import org.objectweb.proactive.core.config.CentralPAPropertyRepository;
 import org.objectweb.proactive.core.util.log.Loggers;
 import org.objectweb.proactive.core.util.log.ProActiveLogger;
+import org.objectweb.proactive.extensions.dataspaces.api.UserCredentials;
 import org.objectweb.proactive.extensions.dataspaces.vfs.VFSMountManagerHelper;
 import org.objectweb.proactive.extensions.pamr.PAMRConfig;
 import org.objectweb.proactive.extensions.pamr.router.Router;
@@ -138,7 +139,7 @@ public class VFSMountManagerHelperTest {
             uriToMount.add(spacesDir.toURI().toString()); // adds a valid file uri
             uriToMount.addAll(fakeUrls);
             uriToMount.add((int) Math.floor(Math.random() * uriToMount.size()), validUrl);
-            VFSMountManagerHelper.mountAny(uriToMount, fileSystems);
+            VFSMountManagerHelper.mountAny(new UserCredentials(), uriToMount, fileSystems);
             logger.info("Content of map : " + fileSystems.toString());
             Assert.assertTrue("map contains valid Url", fileSystems.containsKey(validUrl));
         }
@@ -154,7 +155,7 @@ public class VFSMountManagerHelperTest {
         ArrayList<String> urlsToMount = new ArrayList<String>(fakeFileUrls);
         urlsToMount.addAll(fakeUrls);
         ConcurrentHashMap<String, FileObject> fileSystems = new ConcurrentHashMap<String, FileObject>();
-        VFSMountManagerHelper.mountAny(urlsToMount, fileSystems);
+        VFSMountManagerHelper.mountAny(new UserCredentials(), urlsToMount, fileSystems);
     }
 
     /**
@@ -166,7 +167,7 @@ public class VFSMountManagerHelperTest {
         logger.info("*************** testMountOk");
         String[] validUrls = server.getVFSRootURLs();
         for (String validUrl : validUrls) {
-            FileObject mounted = VFSMountManagerHelper.mount(validUrl);
+            FileObject mounted = VFSMountManagerHelper.mount(new UserCredentials(), validUrl);
             Assert.assertTrue(mounted.exists());
         }
     }
@@ -179,7 +180,7 @@ public class VFSMountManagerHelperTest {
     public void testMountKo() throws Exception {
         logger.info("*************** testMountKo");
         for (String fakeUrl : fakeUrls) {
-            FileObject mounted = VFSMountManagerHelper.mount(fakeUrl);
+            FileObject mounted = VFSMountManagerHelper.mount(new UserCredentials(), fakeUrl);
         }
     }
 
@@ -194,12 +195,12 @@ public class VFSMountManagerHelperTest {
         String[] validUrls = server.getVFSRootURLs();
         ArrayList<FileObject> fos = new ArrayList<FileObject>();
         for (String validUrl : validUrls) {
-            FileObject mounted = VFSMountManagerHelper.mount(validUrl);
+            FileObject mounted = VFSMountManagerHelper.mount(new UserCredentials(), validUrl);
             Assert.assertTrue(mounted.exists());
             fos.add(mounted);
         }
 
-        VFSMountManagerHelper.closeFileSystems(Arrays.asList(validUrls));
+        VFSMountManagerHelper.closeFileSystems(new UserCredentials(), Arrays.asList(validUrls));
 
         boolean onlyExceptions = true;
         for (FileObject closedFo : fos) {

--- a/programming-extensions/programming-extension-dataspaces/src/test/java/dataspaces/VFSSpacesMountManagerImplTest.java
+++ b/programming-extensions/programming-extension-dataspaces/src/test/java/dataspaces/VFSSpacesMountManagerImplTest.java
@@ -258,7 +258,7 @@ public class VFSSpacesMountManagerImplTest {
 
     @Test
     public void testResolveFileForInputSpace() throws IOException, SpaceNotFoundException {
-        fileObject = manager.resolveFile(inputUri, null);
+        fileObject = manager.resolveFile(inputUri, null, null);
         assertIsWorkingInputSpaceDir(fileObject);
     }
 
@@ -276,14 +276,14 @@ public class VFSSpacesMountManagerImplTest {
 
     @Test
     public void testResolveFileForOutputSpace() throws IOException, SpaceNotFoundException {
-        fileObject = manager.resolveFile(outputUri, null);
+        fileObject = manager.resolveFile(outputUri, null, null);
         assertIsWorkingOutputSpaceDir(fileObject);
     }
 
     @Test
     public void testResolveFilesNotSharedFileObject() throws IOException, SpaceNotFoundException {
-        final DataSpacesFileObject fileObject1 = manager.resolveFile(inputUri, null);
-        final DataSpacesFileObject fileObject2 = manager.resolveFile(inputUri, null);
+        final DataSpacesFileObject fileObject1 = manager.resolveFile(inputUri, null, null);
+        final DataSpacesFileObject fileObject2 = manager.resolveFile(inputUri, null, null);
 
         assertNotSame(fileObject1, fileObject2);
     }
@@ -291,7 +291,7 @@ public class VFSSpacesMountManagerImplTest {
     @Test
     public void testResolveFileForUnexistingSpace() throws SpaceNotFoundException, IOException {
         try {
-            manager.resolveFile(NONEXISTING_SPACE, null);
+            manager.resolveFile(NONEXISTING_SPACE, null, null);
             fail("Exception expected");
         } catch (SpaceNotFoundException x) {
         }
@@ -302,7 +302,7 @@ public class VFSSpacesMountManagerImplTest {
         final DataSpacesURI uri = DataSpacesURI.createURI(inputUri.getAppId());
         assertFalse(uri.isSpacePartFullyDefined());
         try {
-            manager.resolveFile(uri, null);
+            manager.resolveFile(uri, null, null);
             fail("Exception expected");
         } catch (IllegalArgumentException x) {
         }
@@ -312,7 +312,7 @@ public class VFSSpacesMountManagerImplTest {
     public void testResolveFileForNotSuitableForUserPath() throws SpaceNotFoundException, IOException {
         assertFalse(scratchUri.isSuitableForUserPath());
         try {
-            manager.resolveFile(scratchUri, null);
+            manager.resolveFile(scratchUri, null, null);
             fail("Exception expected");
         } catch (IllegalArgumentException x) {
         }
@@ -338,7 +338,8 @@ public class VFSSpacesMountManagerImplTest {
                                                                                      fileObjectWithWrongFileUri.getName(),
                                                                                      rootUrisWithWrongFileUri,
                                                                                      wrongpath,
-                                                                                     manager2);
+                                                                                     manager2,
+                                                                                     null);
 
         // switch to existing
         DataSpacesFileObject newfo = dsFileObjectWithWrongFileUri.ensureExistingOrSwitch(true);
@@ -489,7 +490,7 @@ public class VFSSpacesMountManagerImplTest {
     @Test
     public void testResolveFileForFileInInputSpace() throws SpaceNotFoundException, IOException {
         final DataSpacesURI fileUri = inputUri.withUserPath(INPUT_FILE);
-        fileObject = manager.resolveFile(fileUri, null);
+        fileObject = manager.resolveFile(fileUri, null, null);
 
         assertTrue(fileObject.exists());
         // is it that file?
@@ -514,7 +515,7 @@ public class VFSSpacesMountManagerImplTest {
     @Test
     public void testResolveFileForFileInScratchSpaceForOwner() throws SpaceNotFoundException, IOException {
         final DataSpacesURI fileUri = scratchUri.withActiveObjectId(SCRATCH_ACTIVE_OBJECT_ID);
-        fileObject = manager.resolveFile(fileUri, SCRATCH_ACTIVE_OBJECT_ID);
+        fileObject = manager.resolveFile(fileUri, SCRATCH_ACTIVE_OBJECT_ID, null);
         assertIsWorkingScratchForAODir(fileObject, fileUri, true);
     }
 
@@ -522,14 +523,14 @@ public class VFSSpacesMountManagerImplTest {
     public void testResolveFileForFileInScratchSpaceForOtherAO() throws SpaceNotFoundException, IOException {
         final DataSpacesURI fileUri = scratchUri.withActiveObjectId(SCRATCH_ACTIVE_OBJECT_ID);
         final String nonexistingActiveObjectId = SCRATCH_ACTIVE_OBJECT_ID + "toto";
-        fileObject = manager.resolveFile(fileUri, nonexistingActiveObjectId);
+        fileObject = manager.resolveFile(fileUri, nonexistingActiveObjectId, null);
         assertIsWorkingScratchForAODir(fileObject, fileUri, false);
     }
 
     @Test
     public void testResolveFileForFileInScratchSpaceForAnonymousOwner() throws SpaceNotFoundException, IOException {
         final DataSpacesURI fileUri = scratchUri.withActiveObjectId(SCRATCH_ACTIVE_OBJECT_ID);
-        fileObject = manager.resolveFile(fileUri, null);
+        fileObject = manager.resolveFile(fileUri, null, null);
         assertIsWorkingScratchForAODir(fileObject, fileUri, false);
     }
 
@@ -576,7 +577,7 @@ public class VFSSpacesMountManagerImplTest {
     @Test
     public void testResolveFileForUnexistingFileInSpace() throws SpaceNotFoundException, IOException {
         final DataSpacesURI fileUri = inputUri.withUserPath(NONEXISTING_FILE);
-        fileObject = manager.resolveFile(fileUri, null);
+        fileObject = manager.resolveFile(fileUri, null, null);
         assertFalse(fileObject.exists());
     }
 
@@ -598,7 +599,7 @@ public class VFSSpacesMountManagerImplTest {
     public void testResolveFileForFileInNonexistingSpace() throws SpaceNotFoundException, IOException {
         final DataSpacesURI fileUri = NONEXISTING_SPACE.withUserPath(NONEXISTING_FILE);
         try {
-            manager.resolveFile(fileUri, null);
+            manager.resolveFile(fileUri, null, null);
             fail("Exception expected");
         } catch (SpaceNotFoundException x) {
         }
@@ -607,7 +608,7 @@ public class VFSSpacesMountManagerImplTest {
     @Test
     public void testResolveSpaces() throws Exception {
         final DataSpacesURI queryUri = DataSpacesURI.createURI(inputUri.getAppId(), inputUri.getSpaceType());
-        final Map<DataSpacesURI, ? extends DataSpacesFileObject> spaces = manager.resolveSpaces(queryUri, null);
+        final Map<DataSpacesURI, ? extends DataSpacesFileObject> spaces = manager.resolveSpaces(queryUri, null, null);
         assertEquals(1, spaces.size());
 
         fileObject = spaces.get(inputUri);
@@ -631,18 +632,18 @@ public class VFSSpacesMountManagerImplTest {
     public void testResolveSpacesNonexisting() throws SpaceNotFoundException, IOException {
         final String nonexistingRuntimeId = scratchUri.getRuntimeId() + "toto";
         final DataSpacesURI queryUri = DataSpacesURI.createScratchSpaceURI(scratchUri.getAppId(), nonexistingRuntimeId);
-        assertEquals(0, manager.resolveSpaces(queryUri, null).size());
+        assertEquals(0, manager.resolveSpaces(queryUri, null, null).size());
     }
 
     @Test
     public void testResolveSpacesNotSharedFileObject() throws IOException {
         final DataSpacesURI queryUri = DataSpacesURI.createURI(inputUri.getAppId(), inputUri.getSpaceType());
 
-        final Map<DataSpacesURI, ? extends DataSpacesFileObject> spaces1 = manager.resolveSpaces(queryUri, null);
+        final Map<DataSpacesURI, ? extends DataSpacesFileObject> spaces1 = manager.resolveSpaces(queryUri, null, null);
         assertEquals(1, spaces1.size());
         final DataSpacesFileObject fileObject1 = spaces1.get(inputUri);
 
-        final Map<DataSpacesURI, ? extends DataSpacesFileObject> spaces2 = manager.resolveSpaces(queryUri, null);
+        final Map<DataSpacesURI, ? extends DataSpacesFileObject> spaces2 = manager.resolveSpaces(queryUri, null, null);
         assertEquals(1, spaces2.size());
         final DataSpacesFileObject fileObject2 = spaces2.get(inputUri);
         assertNotSame(fileObject1, fileObject2);
@@ -651,7 +652,7 @@ public class VFSSpacesMountManagerImplTest {
     @Test
     public void testResolveSpacesForSpacePartFullyDefined() throws SpaceNotFoundException, IOException {
         try {
-            manager.resolveSpaces(inputUri, null);
+            manager.resolveSpaces(inputUri, null, null);
             fail("Exception expected");
         } catch (IllegalArgumentException x) {
         }
@@ -661,7 +662,7 @@ public class VFSSpacesMountManagerImplTest {
     public void testResolveSpacesForNotSuitableForUserPath() throws SpaceNotFoundException, IOException {
         final DataSpacesURI uri = DataSpacesURI.createScratchSpaceURI(scratchUri.getAppId(), scratchUri.getRuntimeId());
         try {
-            manager.resolveSpaces(uri, null);
+            manager.resolveSpaces(uri, null, null);
             fail("Exception expected");
         } catch (IllegalArgumentException x) {
         }


### PR DESCRIPTION
 - when resolving a file, it is possible to add user credentials
 - these credentials can be used by the underlying apache VFS providers to perform authentication on the file system.
 - Please note that the file:// VFS provider does not support authentication (becase the file provider is not able to perform impersonation). So at the moment only sftp (and possibly samba) support it.
See https://commons.apache.org/proper/commons-vfs/filesystems.html
 - This modification is the first part of the implementation to allow dataspace impersonation, the second part will be in the scheduling project (and the change is much bigger).