### PR TITLE
Replace ServiceRegistry with ServiceLoader

### DIFF
--- a/programming-core/src/main/java/org/objectweb/proactive/core/config/PAProperties.java
+++ b/programming-core/src/main/java/org/objectweb/proactive/core/config/PAProperties.java
@@ -32,8 +32,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-
-import javax.imageio.spi.ServiceRegistry;
+import java.util.ServiceLoader;
 
 import org.apache.log4j.Logger;
 import org.objectweb.proactive.annotation.PublicAPI;
@@ -70,8 +69,7 @@ abstract public class PAProperties {
         // Loads the default central repository
         map = new HashMap<Class<?>, List<PAProperty>>();
 
-        Iterator<PAPropertiesLoaderSPI> iter;
-        iter = ServiceRegistry.lookupProviders(PAPropertiesLoaderSPI.class);
+        Iterator<PAPropertiesLoaderSPI> iter = ServiceLoader.load(PAPropertiesLoaderSPI.class).iterator();
 
         while (iter.hasNext()) {
             try {

--- a/programming-core/src/main/java/org/objectweb/proactive/core/remoteobject/RemoteObjectProtocolFactoryRegistry.java
+++ b/programming-core/src/main/java/org/objectweb/proactive/core/remoteobject/RemoteObjectProtocolFactoryRegistry.java
@@ -28,8 +28,7 @@ package org.objectweb.proactive.core.remoteobject;
 import java.util.Enumeration;
 import java.util.Hashtable;
 import java.util.Iterator;
-
-import javax.imageio.spi.ServiceRegistry;
+import java.util.ServiceLoader;
 
 import org.apache.log4j.Logger;
 import org.objectweb.proactive.core.Constants;
@@ -52,7 +51,7 @@ public class RemoteObjectProtocolFactoryRegistry {
         remoteObjectFactories.put(Constants.XMLHTTP_PROTOCOL_IDENTIFIER, HTTPRemoteObjectFactory.class);
         remoteObjectFactories.put(Constants.RMISSH_PROTOCOL_IDENTIFIER, RmiSshRemoteObjectFactory.class);
 
-        Iterator<RemoteObjectFactorySPI> iter = ServiceRegistry.lookupProviders(RemoteObjectFactorySPI.class);
+        Iterator<RemoteObjectFactorySPI> iter = ServiceLoader.load(RemoteObjectFactorySPI.class).iterator();
         while (iter.hasNext()) {
             try {
                 RemoteObjectFactorySPI remoteObjectFactorySPI = iter.next();

--- a/programming-core/src/main/java/org/objectweb/proactive/core/util/log/remote/ProActiveAppender.java
+++ b/programming-core/src/main/java/org/objectweb/proactive/core/util/log/remote/ProActiveAppender.java
@@ -29,11 +29,10 @@ import java.net.URI;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.ServiceLoader;
 import java.util.Timer;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
-
-import javax.imageio.spi.ServiceRegistry;
 
 import org.apache.log4j.AppenderSkeleton;
 import org.apache.log4j.spi.LoggingEvent;
@@ -153,7 +152,7 @@ public final class ProActiveAppender extends AppenderSkeleton {
         if (provider != null) {
             // User asked for a specific provider
             Iterator<LoggingEventSenderSPI> iter;
-            iter = ServiceRegistry.lookupProviders(LoggingEventSenderSPI.class);
+            iter = ServiceLoader.load(LoggingEventSenderSPI.class).iterator();
             while (iter.hasNext()) {
                 LoggingEventSenderSPI next = iter.next();
                 if (next.getClass().getName().equals(provider)) {
@@ -172,7 +171,7 @@ public final class ProActiveAppender extends AppenderSkeleton {
         // Use the first provider as fallback
         if (spi == null) {
             Iterator<LoggingEventSenderSPI> iter;
-            iter = ServiceRegistry.lookupProviders(LoggingEventSenderSPI.class);
+            iter = ServiceLoader.load(LoggingEventSenderSPI.class).iterator();
             spi = iter.next();
         }
 

--- a/programming-extensions/programming-extension-pamr/src/main/java/org/objectweb/proactive/extensions/pamr/remoteobject/util/socketfactory/PAMRSocketFactorySelector.java
+++ b/programming-extensions/programming-extension-pamr/src/main/java/org/objectweb/proactive/extensions/pamr/remoteobject/util/socketfactory/PAMRSocketFactorySelector.java
@@ -26,8 +26,7 @@
 package org.objectweb.proactive.extensions.pamr.remoteobject.util.socketfactory;
 
 import java.util.Iterator;
-
-import javax.imageio.spi.ServiceRegistry;
+import java.util.ServiceLoader;
 
 import org.apache.log4j.Logger;
 import org.objectweb.proactive.core.util.log.ProActiveLogger;
@@ -56,7 +55,7 @@ public class PAMRSocketFactorySelector {
 
         String socketFactory = PAMRConfig.PA_PAMR_SOCKET_FACTORY.getValue();
 
-        Iterator<PAMRSocketFactorySPI> socketFactories = ServiceRegistry.lookupProviders(PAMRSocketFactorySPI.class);
+        Iterator<PAMRSocketFactorySPI> socketFactories = ServiceLoader.load(PAMRSocketFactorySPI.class).iterator();
         try {
             while (socketFactories.hasNext()) {
                 PAMRSocketFactorySPI factory = socketFactories.next();


### PR DESCRIPTION
ServiceRegistry cannot be used in the same way starting from java 9