### PR TITLE
Improve process builder for windows

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -453,6 +453,15 @@ project(':programming-test') {
                 logger.lifecycle("Running: " + descriptor)
             }
 
+            if (project.hasProperty('runasme.user')) {
+                systemProperties << ['runasme.user': project.property('runasme.user')]
+            }
+            if (project.hasProperty('runasme.pwd')) {
+                systemProperties << ['runasme.pwd': project.property('runasme.pwd')]
+            }
+            if (project.hasProperty('runasme.key.path')) {
+                systemProperties << ['runasme.key.path': project.property('runasme.key.path')]
+            }
             systemProperties << ['proactive.home': rootDir.absolutePath]
             systemProperties << ['proactive.runtime.ping': false]
             systemProperties << ['java.security.policy': file('src/test/resources/proactive.java.policy').absolutePath]

--- a/programming-extensions/programming-extension-processbuilder/src/main/java/org/objectweb/proactive/extensions/processbuilder/BasicProcessBuilder.java
+++ b/programming-extensions/programming-extension-processbuilder/src/main/java/org/objectweb/proactive/extensions/processbuilder/BasicProcessBuilder.java
@@ -101,6 +101,11 @@ public class BasicProcessBuilder implements OSProcessBuilder {
         return this;
     }
 
+    @Override
+    public String getShortPath(String longPath) {
+        return longPath;
+    }
+
     public Process start() throws IOException, OSUserException, CoreBindingException, FatalProcessBuilderException {
         return this.pb.start();
     }

--- a/programming-extensions/programming-extension-processbuilder/src/main/java/org/objectweb/proactive/extensions/processbuilder/LinuxProcessBuilder.java
+++ b/programming-extensions/programming-extension-processbuilder/src/main/java/org/objectweb/proactive/extensions/processbuilder/LinuxProcessBuilder.java
@@ -308,6 +308,11 @@ public class LinuxProcessBuilder implements OSProcessBuilder {
         return this;
     }
 
+    @Override
+    public String getShortPath(String longPath) {
+        return longPath;
+    }
+
     /*
      * (non-Javadoc)
      * 

--- a/programming-extensions/programming-extension-processbuilder/src/main/java/org/objectweb/proactive/extensions/processbuilder/OSProcessBuilder.java
+++ b/programming-extensions/programming-extension-processbuilder/src/main/java/org/objectweb/proactive/extensions/processbuilder/OSProcessBuilder.java
@@ -267,6 +267,8 @@ public interface OSProcessBuilder {
      */
     OSProcessBuilder redirectErrorStream(boolean redirectErrorStream);
 
+    String getShortPath(String longPath) throws IOException;
+
     /**
      * Starts a new process using the attributes of this process builder.
      * 

--- a/programming-extensions/programming-extension-processbuilder/src/main/java/org/objectweb/proactive/extensions/processbuilder/WindowsProcessBuilder.java
+++ b/programming-extensions/programming-extension-processbuilder/src/main/java/org/objectweb/proactive/extensions/processbuilder/WindowsProcessBuilder.java
@@ -222,6 +222,11 @@ public final class WindowsProcessBuilder implements OSProcessBuilder {
         return true;
     }
 
+    @Override
+    public String getShortPath(String longPath) throws IOException {
+        return WindowsProcess.getShortPath(longPath);
+    }
+
     /**
      * Create a native representation of a process that will run in background
      * that means no interaction with the desktop 

--- a/programming-test/src/test/java/functionalTests/processbuilder/test/WindowsAndLinuxTester.java
+++ b/programming-test/src/test/java/functionalTests/processbuilder/test/WindowsAndLinuxTester.java
@@ -61,6 +61,12 @@ public class WindowsAndLinuxTester extends FunctionalTest {
 
     final static boolean isWindows = System.getProperty("os.name").toLowerCase().contains("windows");
 
+    public static final String PROCESSBUILDER_USERNAME_PROPNAME = "runasme.user";
+
+    public static final String PROCESSBUILDER_PASSWORD_PROPNAME = "runasme.pwd";
+
+    public static final String PROCESSBUILDER_TMP_PROPNAME = "runasme.tmp";
+
     // Modify these to fit your environment
     OSUser userPasswd;
 
@@ -78,10 +84,10 @@ public class WindowsAndLinuxTester extends FunctionalTest {
     // ------------------------------------ 
     @Before
     public void shouldRun() throws ProActiveException {
-        String suser = System.getenv("OSPB_TEST_USER");
+        String suser = System.getProperty(PROCESSBUILDER_USERNAME_PROPNAME);
         Assume.assumeNotNull(suser, "process builder not tested because OSPB_TEST_USER is not set");
 
-        String pass = System.getenv("OSPB_TEST_PASS");
+        String pass = System.getProperty(PROCESSBUILDER_PASSWORD_PROPNAME);
         Assume.assumeNotNull(pass, "process builder not tested because OSPB_TEST_PASS is not set");
         userPasswd = new OSUser(suser, pass);
 
@@ -89,7 +95,7 @@ public class WindowsAndLinuxTester extends FunctionalTest {
         //        Assume.assumeNotNull(pass, "process builder not tested because OSPB_TEST_ is not set");
         //        userPasswd = new OSUser(suser, null);
 
-        tempPath = System.getenv("OSPB_TEST_TEMP");
+        tempPath = System.getProperty(PROCESSBUILDER_TMP_PROPNAME);
         Assume.assumeNotNull(tempPath, "process builder not tested because OSPB_TEST_TEMP is not set");
         if (isLinux) {
             String paHome = ProActiveRuntimeImpl.getProActiveRuntime().getProActiveHome();


### PR DESCRIPTION
 - add a getShortPath method to allow reducing paths and avoid command too long issues
 - throw dedicated errors when the command is too long or the provided command directory cannot be used
 - merged runAsMe properties used