### PR TITLE
 Upgrade keycloak related dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -369,8 +369,8 @@ project('programming-extensions:programming-extension-pnpssl') {
         compile(
                 project(':programming-core'),
                 'io.netty:netty:3.10.6.Final',
-                'org.bouncycastle:bcprov-jdk15to18:1.74',
-                'org.bouncycastle:bcprov-ext-jdk15to18:1.74',
+                'org.bouncycastle:bcprov-jdk15to18:1.77',
+                'org.bouncycastle:bcprov-ext-jdk15to18:1.77',
 
                 project(':programming-extensions:programming-extension-pnp')
         )


### PR DESCRIPTION
Upgrade the following dependencies to the versions mentioned in **bold**:

- org.bouncycastle:bcprov-jdk18on:**1.77**
- org.bouncycastle:bcutil-jdk18on:**1.77**

